### PR TITLE
fix: Add network security config

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -7,7 +7,10 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="tech.relaycorp.gateway.SYNC" />
 
-  <application>
+  <application
+      android:networkSecurityConfig="@xml/network_security_config"
+      tools:ignore="UnusedAttribute"
+      >
     <receiver
         android:name=".background.NotificationBroadcastReceiver"
         tools:ignore="ExportedReceiver">

--- a/lib/src/main/res/xml/network_security_config.xml
+++ b/lib/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow local cleartext networking with PDC Server -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
This was missing from the SDK, and it is required so Android allows plain-text communication with the gateway app. We have the same thing in the Gateway app.