### PR TITLE
fix: Add SYNC permission definition

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -4,6 +4,10 @@
     package="tech.relaycorp.awaladroid"
     >
 
+   <permission
+      android:name="tech.relaycorp.gateway.SYNC"
+      android:label="Gateway Sync" />
+
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="tech.relaycorp.gateway.SYNC" />
 


### PR DESCRIPTION
If the Ping app is installed without the Gateway app, and the Gateway app is later installed, a security exception will be thrown from the Ping app for missing a permission. That's because the permission was just defined on the Gateway app, and non-existent at the time of installation.

Defining it in both places should fix the issue.