### PR TITLE
fix: Require API 26 or newer

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,7 +14,7 @@ android {
   buildToolsVersion "30.0.3"
 
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion 26  // https://github.com/relaycorp/awala-endpoint-android/issues/87
     targetSdkVersion 30
     versionCode 1
     versionName "1.0.0"


### PR DESCRIPTION
See: https://github.com/relaycorp/awala-endpoint-android/issues/87
