### PR TITLE
fix(release): Make JitPack use Java 11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
 # configuration file for building snapshots and releases with jitpack.io
 jdk:
-    - openjdk11
+  - openjdk11


### PR DESCRIPTION
Or else APG 7 will error out.

See https://github.com/jitpack/jitpack.io/issues/4474