### PR TITLE
fix: Reinstate use of Android Keystore

### DIFF
--- a/lib/src/main/java/tech/relaycorp/awaladroid/AndroidPrivateKeyStore.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/AndroidPrivateKeyStore.kt
@@ -10,13 +10,10 @@ import tech.relaycorp.awala.keystores.file.FilePrivateKeyStore
 internal class AndroidPrivateKeyStore(
     root: FileKeystoreRoot,
     private val context: Context,
-    private val enableEncryption: Boolean = false,
 ) : FilePrivateKeyStore(root) {
-    override fun makeEncryptedInputStream(file: File) =
-        if (enableEncryption) buildEncryptedFile(file).openFileInput() else file.inputStream()
+    override fun makeEncryptedInputStream(file: File) = buildEncryptedFile(file).openFileInput()
 
-    override fun makeEncryptedOutputStream(file: File) =
-        if (enableEncryption) buildEncryptedFile(file).openFileOutput() else file.outputStream()
+    override fun makeEncryptedOutputStream(file: File) = buildEncryptedFile(file).openFileOutput()
 
     private fun buildEncryptedFile(file: File) =
         EncryptedFile.Builder(


### PR DESCRIPTION
Turns out https://issuetracker.google.com/issues/168238828 was caused by a second use of the Keystore in the same app (fixed by #164).
