### PR TITLE
feat: Re-issue/send PDAs when first-party endpoint certificates are renewed

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -76,9 +76,6 @@ dependencies {
   // Serialization
   implementation 'org.mongodb:bson:4.5.1'
 
-  // Preferences
-  implementation 'com.fredporciuncula:flow-preferences:1.5.0'
-
   // Testing
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test:core:1.4.0'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -76,7 +76,10 @@ dependencies {
   // Serialization
   implementation 'org.mongodb:bson:4.5.1'
 
-  // Testing
+  // Preferences
+  implementation 'com.fredporciuncula:flow-preferences:1.5.0'
+
+    // Testing
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test:core:1.4.0'
   testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -79,7 +79,7 @@ dependencies {
   // Preferences
   implementation 'com.fredporciuncula:flow-preferences:1.5.0'
 
-    // Testing
+  // Testing
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test:core:1.4.0'
   testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -64,7 +64,7 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
 
   // Awala
-  implementation 'tech.relaycorp:awala:1.63.1'
+  implementation 'tech.relaycorp:awala:1.64.0'
   implementation 'tech.relaycorp:awala-keystore-file:1.6.0'
   implementation 'tech.relaycorp:poweb:1.5.24'
   testImplementation 'tech.relaycorp:awala-testing:1.5.0'
@@ -86,6 +86,7 @@ dependencies {
   testImplementation 'org.robolectric:robolectric:4.7.3'
   testImplementation 'org.mockito:mockito-inline:4.0.0'
   testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
+  testImplementation 'io.github.hakky54:logcaptor:2.7.9'
 
   // Instrumentation Testing
   androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/lib/src/main/java/tech/relaycorp/awaladroid/Awala.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/Awala.kt
@@ -2,10 +2,12 @@ package tech.relaycorp.awaladroid
 
 import android.content.Context
 import java.io.File
+import kotlinx.coroutines.Dispatchers
 import tech.relaycorp.awala.keystores.file.FileCertificateStore
 import tech.relaycorp.awala.keystores.file.FileKeystoreRoot
 import tech.relaycorp.awala.keystores.file.FileSessionPublicKeystore
 import tech.relaycorp.awaladroid.background.ServiceInteractor
+import tech.relaycorp.awaladroid.endpoint.ChannelManager
 import tech.relaycorp.awaladroid.storage.StorageImpl
 import tech.relaycorp.awaladroid.storage.persistence.DiskPersistence
 import tech.relaycorp.relaynet.nodes.EndpointManager
@@ -32,12 +34,15 @@ public object Awala {
         val androidPrivateKeyStore = AndroidPrivateKeyStore(keystoreRoot, context)
         val fileSessionPublicKeystore = FileSessionPublicKeystore(keystoreRoot)
         val fileCertificateStore = FileCertificateStore(keystoreRoot)
+        val channelPreferences =
+            context.getSharedPreferences("awaladroid-channels", Context.MODE_PRIVATE)
         this.context = AwalaContext(
             StorageImpl(DiskPersistence(context)),
             GatewayClientImpl(
                 serviceInteractorBuilder = { ServiceInteractor(context) }
             ),
             EndpointManager(androidPrivateKeyStore, fileSessionPublicKeystore),
+            ChannelManager(channelPreferences, Dispatchers.IO),
             androidPrivateKeyStore,
             fileSessionPublicKeystore,
             fileCertificateStore,

--- a/lib/src/main/java/tech/relaycorp/awaladroid/Awala.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/Awala.kt
@@ -33,15 +33,15 @@ public object Awala {
         val androidPrivateKeyStore = AndroidPrivateKeyStore(keystoreRoot, context)
         val fileSessionPublicKeystore = FileSessionPublicKeystore(keystoreRoot)
         val fileCertificateStore = FileCertificateStore(keystoreRoot)
-        val channelPreferences =
-            context.getSharedPreferences("awaladroid-channels", Context.MODE_PRIVATE)
         this.context = AwalaContext(
             StorageImpl(DiskPersistence(context)),
             GatewayClientImpl(
                 serviceInteractorBuilder = { ServiceInteractor(context) }
             ),
             EndpointManager(androidPrivateKeyStore, fileSessionPublicKeystore),
-            ChannelManager(channelPreferences),
+            ChannelManager {
+                context.getSharedPreferences("awaladroid-channels", Context.MODE_PRIVATE)
+            },
             androidPrivateKeyStore,
             fileSessionPublicKeystore,
             fileCertificateStore,

--- a/lib/src/main/java/tech/relaycorp/awaladroid/Awala.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/Awala.kt
@@ -2,7 +2,6 @@ package tech.relaycorp.awaladroid
 
 import android.content.Context
 import java.io.File
-import kotlinx.coroutines.Dispatchers
 import tech.relaycorp.awala.keystores.file.FileCertificateStore
 import tech.relaycorp.awala.keystores.file.FileKeystoreRoot
 import tech.relaycorp.awala.keystores.file.FileSessionPublicKeystore
@@ -42,7 +41,7 @@ public object Awala {
                 serviceInteractorBuilder = { ServiceInteractor(context) }
             ),
             EndpointManager(androidPrivateKeyStore, fileSessionPublicKeystore),
-            ChannelManager(channelPreferences, Dispatchers.IO),
+            ChannelManager(channelPreferences),
             androidPrivateKeyStore,
             fileSessionPublicKeystore,
             fileCertificateStore,

--- a/lib/src/main/java/tech/relaycorp/awaladroid/AwalaContext.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/AwalaContext.kt
@@ -1,5 +1,6 @@
 package tech.relaycorp.awaladroid
 
+import tech.relaycorp.awaladroid.endpoint.ChannelManager
 import tech.relaycorp.awaladroid.storage.StorageImpl
 import tech.relaycorp.relaynet.keystores.CertificateStore
 import tech.relaycorp.relaynet.keystores.PrivateKeyStore
@@ -10,7 +11,8 @@ internal data class AwalaContext(
     val storage: StorageImpl,
     val gatewayClient: GatewayClientImpl,
     val endpointManager: EndpointManager,
+    val channelManager: ChannelManager,
     val privateKeyStore: PrivateKeyStore,
     val sessionPublicKeyStore: SessionPublicKeyStore,
-    val certificateStore: CertificateStore
+    val certificateStore: CertificateStore,
 )

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
@@ -8,7 +8,7 @@ internal class ChannelManager(
     sharedPreferences: SharedPreferences,
     coroutineContext: CoroutineContext
 ) {
-    private val flowSharedPreferences: FlowSharedPreferences =
+    internal val flowSharedPreferences: FlowSharedPreferences =
         FlowSharedPreferences(sharedPreferences, coroutineContext)
 
     suspend fun create(

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
@@ -8,11 +8,12 @@ import kotlinx.coroutines.Dispatchers
 import tech.relaycorp.relaynet.wrappers.privateAddress
 
 internal class ChannelManager(
-    sharedPreferences: SharedPreferences,
-    coroutineContext: CoroutineContext = Dispatchers.IO
+    coroutineContext: CoroutineContext = Dispatchers.IO,
+    sharedPreferencesGetter: () -> SharedPreferences
 ) {
-    internal val flowSharedPreferences: FlowSharedPreferences =
-        FlowSharedPreferences(sharedPreferences, coroutineContext)
+    internal val flowSharedPreferences: FlowSharedPreferences by lazy {
+        FlowSharedPreferences(sharedPreferencesGetter(), coroutineContext)
+    }
 
     suspend fun create(
         firstPartyEndpoint: FirstPartyEndpoint,

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
@@ -1,0 +1,54 @@
+package tech.relaycorp.awaladroid.endpoint
+
+import android.content.SharedPreferences
+import com.fredporciuncula.flow.preferences.FlowSharedPreferences
+import kotlin.coroutines.CoroutineContext
+
+internal class ChannelManager(
+    sharedPreferences: SharedPreferences,
+    coroutineContext: CoroutineContext
+) {
+    private val flowSharedPreferences: FlowSharedPreferences =
+        FlowSharedPreferences(sharedPreferences, coroutineContext)
+
+    suspend fun create(
+        firstPartyEndpoint: FirstPartyEndpoint,
+        thirdPartyEndpoint: ThirdPartyEndpoint
+    ) {
+        val preference =
+            flowSharedPreferences.getNullableStringSet(firstPartyEndpoint.privateAddress, null)
+        val originalValues = preference.get() ?: emptySet()
+        preference.setAndCommit(originalValues + mutableListOf(thirdPartyEndpoint.privateAddress))
+    }
+
+    suspend fun delete(
+        firstPartyEndpoint: FirstPartyEndpoint,
+    ) {
+        val preference =
+            flowSharedPreferences.getNullableStringSet(firstPartyEndpoint.privateAddress, null)
+        preference.deleteAndCommit()
+    }
+
+    suspend fun delete(
+        thirdPartyEndpoint: ThirdPartyEndpoint
+    ) {
+        flowSharedPreferences.sharedPreferences.all.forEach { (key, value) ->
+            // Skip malformed values
+            if (value !is MutableSet<*>) {
+                return@forEach
+            }
+            val sanitizedValue: List<String> = value.filterIsInstance<String>()
+            if (value.size != sanitizedValue.size) {
+                return@forEach
+            }
+
+            if ((value).contains(thirdPartyEndpoint.privateAddress)) {
+                val newValue = sanitizedValue.filter { it != thirdPartyEndpoint.privateAddress }
+                flowSharedPreferences.getStringSet(key).setAndCommit(newValue.toMutableSet())
+            }
+        }
+    }
+
+    fun getLinkedEndpointAddresses(firstPartyEndpoint: FirstPartyEndpoint): Set<String> =
+        flowSharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, emptySet()).get()
+}

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
@@ -4,11 +4,12 @@ import android.content.SharedPreferences
 import com.fredporciuncula.flow.preferences.FlowSharedPreferences
 import java.security.PublicKey
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.Dispatchers
 import tech.relaycorp.relaynet.wrappers.privateAddress
 
 internal class ChannelManager(
     sharedPreferences: SharedPreferences,
-    coroutineContext: CoroutineContext
+    coroutineContext: CoroutineContext = Dispatchers.IO
 ) {
     internal val flowSharedPreferences: FlowSharedPreferences =
         FlowSharedPreferences(sharedPreferences, coroutineContext)

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
@@ -2,7 +2,9 @@ package tech.relaycorp.awaladroid.endpoint
 
 import android.content.SharedPreferences
 import com.fredporciuncula.flow.preferences.FlowSharedPreferences
+import java.security.PublicKey
 import kotlin.coroutines.CoroutineContext
+import tech.relaycorp.relaynet.wrappers.privateAddress
 
 internal class ChannelManager(
     sharedPreferences: SharedPreferences,
@@ -15,10 +17,24 @@ internal class ChannelManager(
         firstPartyEndpoint: FirstPartyEndpoint,
         thirdPartyEndpoint: ThirdPartyEndpoint
     ) {
+        create(firstPartyEndpoint, thirdPartyEndpoint.privateAddress)
+    }
+
+    suspend fun create(
+        firstPartyEndpoint: FirstPartyEndpoint,
+        thirdPartyEndpointPublicKey: PublicKey
+    ) {
+        create(firstPartyEndpoint, thirdPartyEndpointPublicKey.privateAddress)
+    }
+
+    private suspend fun create(
+        firstPartyEndpoint: FirstPartyEndpoint,
+        thirdPartyEndpointPrivateAddress: String
+    ) {
         val preference =
             flowSharedPreferences.getNullableStringSet(firstPartyEndpoint.privateAddress, null)
         val originalValues = preference.get() ?: emptySet()
-        preference.setAndCommit(originalValues + mutableListOf(thirdPartyEndpoint.privateAddress))
+        preference.setAndCommit(originalValues + mutableListOf(thirdPartyEndpointPrivateAddress))
     }
 
     suspend fun delete(

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpoint.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpoint.kt
@@ -96,6 +96,7 @@ internal constructor(
         val context = Awala.getContextOrThrow()
         context.privateKeyStore.deleteKeys(privateAddress)
         context.certificateStore.delete(privateAddress, identityCertificate.issuerCommonName)
+        context.channelManager.delete(this)
     }
 
     public companion object {

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ThirdPartyEndpoint.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ThirdPartyEndpoint.kt
@@ -30,6 +30,7 @@ public sealed class ThirdPartyEndpoint(
         val context = Awala.getContextOrThrow()
         context.privateKeyStore.deleteSessionKeysForPeer(privateAddress)
         context.sessionPublicKeyStore.delete(privateAddress)
+        context.channelManager.delete(this)
     }
 
     internal companion object {

--- a/lib/src/test/java/tech/relaycorp/awaladroid/AwalaTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/AwalaTest.kt
@@ -69,10 +69,10 @@ public class AwalaTest {
 
         val context = Awala.getContextOrThrow()
 
-        verify(androidContextSpy).getSharedPreferences("awaladroid-channels", Context.MODE_PRIVATE)
         assertEquals(
             Dispatchers.IO,
             context.channelManager.flowSharedPreferences.coroutineContext,
         )
+        verify(androidContextSpy).getSharedPreferences("awaladroid-channels", Context.MODE_PRIVATE)
     }
 }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/AwalaTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/AwalaTest.kt
@@ -69,10 +69,9 @@ public class AwalaTest {
 
         val context = Awala.getContextOrThrow()
 
-        assertEquals(
-            Dispatchers.IO,
-            context.channelManager.flowSharedPreferences.coroutineContext,
-        )
+        assertEquals(Dispatchers.IO, context.channelManager.coroutineContext)
+        // Cause shared preferences to be resolved before inspecting it
+        context.channelManager.sharedPreferences
         verify(androidContextSpy).getSharedPreferences("awaladroid-channels", Context.MODE_PRIVATE)
     }
 }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/AwalaTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/AwalaTest.kt
@@ -1,6 +1,10 @@
 package tech.relaycorp.awaladroid
 
+import android.content.Context
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.verify
 import java.io.File
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -34,7 +38,7 @@ public class AwalaTest {
     }
 
     @Test
-    public fun keystoresRoot(): Unit = runBlockingTest {
+    public fun keystores(): Unit = runBlockingTest {
         val androidContext = RuntimeEnvironment.getApplication()
         Awala.setUp(androidContext)
 
@@ -55,6 +59,20 @@ public class AwalaTest {
         assertEquals(
             expectedRoot,
             (context.certificateStore as FileCertificateStore).rootDirectory.parentFile,
+        )
+    }
+
+    @Test
+    public fun channelManager(): Unit = runBlockingTest {
+        val androidContextSpy = spy(RuntimeEnvironment.getApplication())
+        Awala.setUp(androidContextSpy)
+
+        val context = Awala.getContextOrThrow()
+
+        verify(androidContextSpy).getSharedPreferences("awaladroid-channels", Context.MODE_PRIVATE)
+        assertEquals(
+            Dispatchers.IO,
+            context.channelManager.flowSharedPreferences.coroutineContext,
         )
     }
 }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
@@ -33,7 +33,7 @@ internal class ChannelManagerTest {
 
     @Test
     fun constructor_defaultCoroutineContext() {
-        val manager = ChannelManager(sharedPreferences)
+        val manager = ChannelManager { sharedPreferences }
 
         assertEquals(Dispatchers.IO, manager.flowSharedPreferences.coroutineContext)
     }
@@ -44,7 +44,7 @@ internal class ChannelManagerTest {
             null,
             sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
         )
-        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val manager = ChannelManager(coroutineContext) { sharedPreferences }
 
         manager.create(firstPartyEndpoint, thirdPartyEndpoint)
 
@@ -56,7 +56,7 @@ internal class ChannelManagerTest {
 
     @Test
     fun create_existing() = runBlockingTest {
-        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val manager = ChannelManager(coroutineContext) { sharedPreferences }
         manager.create(firstPartyEndpoint, thirdPartyEndpoint)
 
         manager.create(firstPartyEndpoint, thirdPartyEndpoint)
@@ -69,7 +69,7 @@ internal class ChannelManagerTest {
 
     @Test
     fun create_with_thirdPartyEndpointPublicKey() = runBlockingTest {
-        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val manager = ChannelManager(coroutineContext) { sharedPreferences }
         manager.create(firstPartyEndpoint, thirdPartyEndpoint.identityKey)
 
         manager.create(firstPartyEndpoint, thirdPartyEndpoint)
@@ -82,7 +82,7 @@ internal class ChannelManagerTest {
 
     @Test
     fun delete_first_party_non_existing() = runBlockingTest {
-        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val manager = ChannelManager(coroutineContext) { sharedPreferences }
 
         manager.delete(firstPartyEndpoint)
 
@@ -94,7 +94,7 @@ internal class ChannelManagerTest {
 
     @Test
     fun delete_first_party_existing() = runBlockingTest {
-        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val manager = ChannelManager(coroutineContext) { sharedPreferences }
         manager.create(firstPartyEndpoint, thirdPartyEndpoint)
 
         manager.delete(firstPartyEndpoint)
@@ -107,7 +107,7 @@ internal class ChannelManagerTest {
 
     @Test
     fun delete_third_party_non_existing() = runBlockingTest {
-        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val manager = ChannelManager(coroutineContext) { sharedPreferences }
         val unrelatedThirdPartyEndpointAddress = "i-have-nothing-to-do-with-the-other"
         with(sharedPreferences.edit()) {
             putStringSet(
@@ -127,7 +127,7 @@ internal class ChannelManagerTest {
 
     @Test
     fun delete_third_party_existing() = runBlockingTest {
-        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val manager = ChannelManager(coroutineContext) { sharedPreferences }
         val unrelatedThirdPartyEndpointAddress = "i-have-nothing-to-do-with-the-other"
         with(sharedPreferences.edit()) {
             putStringSet(
@@ -147,7 +147,7 @@ internal class ChannelManagerTest {
 
     @Test
     fun delete_third_party_single_valued() = runBlockingTest {
-        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val manager = ChannelManager(coroutineContext) { sharedPreferences }
         val malformedValue = "i-should-not-be-here"
         with(sharedPreferences.edit()) {
             putString(
@@ -167,7 +167,7 @@ internal class ChannelManagerTest {
 
     @Test
     fun delete_third_party_invalid_type() = runBlockingTest {
-        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val manager = ChannelManager(coroutineContext) { sharedPreferences }
         val malformedValue = 42
         with(sharedPreferences.edit()) {
             putInt(
@@ -187,7 +187,7 @@ internal class ChannelManagerTest {
 
     @Test
     fun getLinkedEndpointAddresses_empty() = runBlockingTest {
-        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val manager = ChannelManager(coroutineContext) { sharedPreferences }
 
         val linkedEndpoints = manager.getLinkedEndpointAddresses(firstPartyEndpoint)
 
@@ -196,7 +196,7 @@ internal class ChannelManagerTest {
 
     @Test
     fun getLinkedEndpointAddresses_matches() = runBlockingTest {
-        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val manager = ChannelManager(coroutineContext) { sharedPreferences }
         manager.create(firstPartyEndpoint, thirdPartyEndpoint)
 
         val linkedEndpoints = manager.getLinkedEndpointAddresses(firstPartyEndpoint)

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
@@ -60,6 +60,19 @@ internal class ChannelManagerTest {
     }
 
     @Test
+    fun create_with_thirdPartyEndpointPublicKey() = runBlockingTest {
+        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        manager.create(firstPartyEndpoint, thirdPartyEndpoint.identityKey)
+
+        manager.create(firstPartyEndpoint, thirdPartyEndpoint)
+
+        assertEquals(
+            setOf(thirdPartyEndpoint.privateAddress),
+            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+        )
+    }
+
+    @Test
     fun delete_first_party_non_existing() = runBlockingTest {
         val manager = ChannelManager(sharedPreferences, coroutineContext)
 

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
@@ -35,7 +35,7 @@ internal class ChannelManagerTest {
     fun constructor_defaultCoroutineContext() {
         val manager = ChannelManager { sharedPreferences }
 
-        assertEquals(Dispatchers.IO, manager.flowSharedPreferences.coroutineContext)
+        assertEquals(Dispatchers.IO, manager.coroutineContext)
     }
 
     @Test

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
@@ -1,6 +1,7 @@
 package tech.relaycorp.awaladroid.endpoint
 
 import android.content.Context
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -28,6 +29,13 @@ internal class ChannelManagerTest {
             clear()
             apply()
         }
+    }
+
+    @Test
+    fun constructor_defaultCoroutineContext() {
+        val manager = ChannelManager(sharedPreferences)
+
+        assertEquals(Dispatchers.IO, manager.flowSharedPreferences.coroutineContext)
     }
 
     @Test

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
@@ -1,0 +1,185 @@
+package tech.relaycorp.awaladroid.endpoint
+
+import android.content.Context
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import tech.relaycorp.awaladroid.test.FirstPartyEndpointFactory
+import tech.relaycorp.awaladroid.test.ThirdPartyEndpointFactory
+
+@RunWith(RobolectricTestRunner::class)
+internal class ChannelManagerTest {
+    private val androidContext = RuntimeEnvironment.getApplication()
+    private val sharedPreferences = androidContext.getSharedPreferences(
+        "channel-test",
+        Context.MODE_PRIVATE
+    )
+
+    private val firstPartyEndpoint = FirstPartyEndpointFactory.build()
+    private val thirdPartyEndpoint = ThirdPartyEndpointFactory.buildPrivate()
+
+    @After
+    fun clearPreferences() {
+        with(sharedPreferences.edit()) {
+            clear()
+            apply()
+        }
+    }
+
+    @Test
+    fun create_non_existing() = runBlockingTest {
+        assertEquals(
+            null,
+            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+        )
+        val manager = ChannelManager(sharedPreferences, coroutineContext)
+
+        manager.create(firstPartyEndpoint, thirdPartyEndpoint)
+
+        assertEquals(
+            setOf(thirdPartyEndpoint.privateAddress),
+            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+        )
+    }
+
+    @Test
+    fun create_existing() = runBlockingTest {
+        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        manager.create(firstPartyEndpoint, thirdPartyEndpoint)
+
+        manager.create(firstPartyEndpoint, thirdPartyEndpoint)
+
+        assertEquals(
+            setOf(thirdPartyEndpoint.privateAddress),
+            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+        )
+    }
+
+    @Test
+    fun delete_first_party_non_existing() = runBlockingTest {
+        val manager = ChannelManager(sharedPreferences, coroutineContext)
+
+        manager.delete(firstPartyEndpoint)
+
+        assertEquals(
+            null,
+            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+        )
+    }
+
+    @Test
+    fun delete_first_party_existing() = runBlockingTest {
+        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        manager.create(firstPartyEndpoint, thirdPartyEndpoint)
+
+        manager.delete(firstPartyEndpoint)
+
+        assertEquals(
+            null,
+            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+        )
+    }
+
+    @Test
+    fun delete_third_party_non_existing() = runBlockingTest {
+        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val unrelatedThirdPartyEndpointAddress = "i-have-nothing-to-do-with-the-other"
+        with(sharedPreferences.edit()) {
+            putStringSet(
+                firstPartyEndpoint.privateAddress,
+                mutableSetOf(unrelatedThirdPartyEndpointAddress)
+            )
+            apply()
+        }
+
+        manager.delete(thirdPartyEndpoint)
+
+        assertEquals(
+            mutableSetOf(unrelatedThirdPartyEndpointAddress),
+            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+        )
+    }
+
+    @Test
+    fun delete_third_party_existing() = runBlockingTest {
+        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val unrelatedThirdPartyEndpointAddress = "i-have-nothing-to-do-with-the-other"
+        with(sharedPreferences.edit()) {
+            putStringSet(
+                firstPartyEndpoint.privateAddress,
+                mutableSetOf(unrelatedThirdPartyEndpointAddress, thirdPartyEndpoint.privateAddress)
+            )
+            apply()
+        }
+
+        manager.delete(thirdPartyEndpoint)
+
+        assertEquals(
+            setOf(unrelatedThirdPartyEndpointAddress),
+            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+        )
+    }
+
+    @Test
+    fun delete_third_party_single_valued() = runBlockingTest {
+        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val malformedValue = "i-should-not-be-here"
+        with(sharedPreferences.edit()) {
+            putString(
+                firstPartyEndpoint.privateAddress,
+                malformedValue
+            )
+            apply()
+        }
+
+        manager.delete(thirdPartyEndpoint)
+
+        assertEquals(
+            malformedValue,
+            sharedPreferences.getString(firstPartyEndpoint.privateAddress, null)
+        )
+    }
+
+    @Test
+    fun delete_third_party_invalid_type() = runBlockingTest {
+        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        val malformedValue = 42
+        with(sharedPreferences.edit()) {
+            putInt(
+                firstPartyEndpoint.privateAddress,
+                malformedValue
+            )
+            apply()
+        }
+
+        manager.delete(thirdPartyEndpoint)
+
+        assertEquals(
+            malformedValue,
+            sharedPreferences.getInt(firstPartyEndpoint.privateAddress, 0)
+        )
+    }
+
+    @Test
+    fun getLinkedEndpointAddresses_empty() = runBlockingTest {
+        val manager = ChannelManager(sharedPreferences, coroutineContext)
+
+        val linkedEndpoints = manager.getLinkedEndpointAddresses(firstPartyEndpoint)
+
+        assertEquals(0, linkedEndpoints.size)
+    }
+
+    @Test
+    fun getLinkedEndpointAddresses_matches() = runBlockingTest {
+        val manager = ChannelManager(sharedPreferences, coroutineContext)
+        manager.create(firstPartyEndpoint, thirdPartyEndpoint)
+
+        val linkedEndpoints = manager.getLinkedEndpointAddresses(firstPartyEndpoint)
+
+        assertEquals(setOf(thirdPartyEndpoint.privateAddress), linkedEndpoints)
+    }
+}

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpointTest.kt
@@ -388,10 +388,11 @@ internal class FirstPartyEndpointTest : MockContextTestCase() {
 }
 
 private fun validateAuthorization(
-    authorization: CertificationPath,
+    authorizationSerialized: ByteArray,
     firstPartyEndpoint: FirstPartyEndpoint,
     expiryDate: ZonedDateTime
 ) {
+    val authorization = CertificationPath.deserialize(authorizationSerialized)
     // PDA
     val pda = authorization.leafCertificate
     assertEquals(

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpointTest.kt
@@ -265,6 +265,7 @@ internal class FirstPartyEndpointTest : MockContextTestCase() {
 
         assertEquals(0, privateKeyStore.identityKeys.size)
         assertEquals(0, certificateStore.certificationPaths.size)
+        verify(channelManager).delete(endpoint)
     }
 }
 

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PrivateThirdPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PrivateThirdPartyEndpointTest.kt
@@ -246,7 +246,7 @@ internal class PrivateThirdPartyEndpointTest : MockContextTestCase() {
         endpoint.delete()
 
         verify(storage.privateThirdParty)
-            .delete("${endpoint.pda.subjectPrivateAddress}_${endpoint.privateAddress}")
+            .delete("${firstPartyEndpoint.privateAddress}_${endpoint.privateAddress}")
         assertEquals(0, privateKeyStore.sessionKeys[firstPartyEndpoint.privateAddress]!!.size)
         assertEquals(0, sessionPublicKeystore.keys.size)
         verify(channelManager).delete(endpoint)

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PrivateThirdPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PrivateThirdPartyEndpointTest.kt
@@ -249,5 +249,6 @@ internal class PrivateThirdPartyEndpointTest : MockContextTestCase() {
             .delete("${endpoint.pda.subjectPrivateAddress}_${endpoint.privateAddress}")
         assertEquals(0, privateKeyStore.sessionKeys[firstPartyEndpoint.privateAddress]!!.size)
         assertEquals(0, sessionPublicKeystore.keys.size)
+        verify(channelManager).delete(endpoint)
     }
 }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointTest.kt
@@ -126,5 +126,6 @@ internal class PublicThirdPartyEndpointTest : MockContextTestCase() {
         verify(storage.publicThirdParty).delete(thirdPartyEndpoint.privateAddress)
         assertEquals(0, privateKeyStore.sessionKeys[firstPartyEndpoint.privateAddress]!!.size)
         assertEquals(0, sessionPublicKeystore.keys.size)
+        verify(channelManager).delete(thirdPartyEndpoint)
     }
 }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/IncomingMessageTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/IncomingMessageTest.kt
@@ -3,13 +3,9 @@ package tech.relaycorp.awaladroid.messaging
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
-import tech.relaycorp.awaladroid.endpoint.PublicThirdPartyEndpointData
-import tech.relaycorp.awaladroid.storage.StorageImpl
 import tech.relaycorp.awaladroid.test.EndpointChannel
 import tech.relaycorp.awaladroid.test.MockContextTestCase
-import tech.relaycorp.awaladroid.test.MockPersistence
 import tech.relaycorp.relaynet.messages.Parcel
 import tech.relaycorp.relaynet.messages.payloads.ServiceMessage
 import tech.relaycorp.relaynet.nodes.EndpointManager
@@ -19,23 +15,10 @@ import tech.relaycorp.relaynet.testing.keystores.MockSessionPublicKeyStore
 import tech.relaycorp.relaynet.testing.pki.PDACertPath
 
 internal class IncomingMessageTest : MockContextTestCase() {
-    private val persistence = MockPersistence()
-    override val storage = StorageImpl(persistence)
-
-    @Before
-    fun resetPersistence() = persistence.reset()
-
     @Test
     fun buildFromParcel() = runBlockingTest {
         val serviceMessage = ServiceMessage("the type", "the content".toByteArray())
         val channel = createEndpointChannel(RecipientAddressType.PUBLIC)
-        storage.publicThirdParty.set(
-            channel.thirdPartyEndpoint.privateAddress,
-            PublicThirdPartyEndpointData(
-                channel.thirdPartyEndpoint.address,
-                channel.thirdPartyEndpoint.identityKey,
-            )
-        )
         val thirdPartyEndpointManager = makeThirdPartyEndpointManager(channel)
         val parcel = Parcel(
             recipientAddress = channel.firstPartyEndpoint.privateAddress,

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/ReceiveMessagesTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/ReceiveMessagesTest.kt
@@ -8,14 +8,11 @@ import kotlinx.coroutines.flow.toCollection
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 import tech.relaycorp.awaladroid.GatewayProtocolException
 import tech.relaycorp.awaladroid.endpoint.PublicThirdPartyEndpointData
-import tech.relaycorp.awaladroid.storage.StorageImpl
 import tech.relaycorp.awaladroid.test.EndpointChannel
 import tech.relaycorp.awaladroid.test.MockContextTestCase
-import tech.relaycorp.awaladroid.test.MockPersistence
 import tech.relaycorp.relaynet.bindings.pdc.ClientBindingException
 import tech.relaycorp.relaynet.bindings.pdc.NonceSignerException
 import tech.relaycorp.relaynet.bindings.pdc.ParcelCollection
@@ -37,24 +34,11 @@ internal class ReceiveMessagesTest : MockContextTestCase() {
     private lateinit var pdcClient: MockPDCClient
     private val subject = ReceiveMessages { pdcClient }
 
-    private val persistence = MockPersistence()
-    override val storage = StorageImpl(persistence)
-
     private val serviceMessage = ServiceMessage("type", "content".toByteArray())
-
-    @Before
-    fun resetPersistence() = persistence.reset()
 
     @Test
     fun receiveParcelSuccessfully() = runBlockingTest {
         val channel = createEndpointChannel(RecipientAddressType.PUBLIC)
-        storage.publicThirdParty.set(
-            channel.thirdPartyEndpoint.privateAddress,
-            PublicThirdPartyEndpointData(
-                channel.thirdPartyEndpoint.address,
-                channel.thirdPartyEndpoint.identityKey,
-            )
-        )
         val parcel = buildParcel(channel)
         val parcelCollection = parcel.toParcelCollection()
         val collectParcelsCall = CollectParcelsCall(Result.success(flowOf(parcelCollection)))
@@ -70,13 +54,6 @@ internal class ReceiveMessagesTest : MockContextTestCase() {
     @Test
     fun collectParcelsWithCorrectNonceSigners() = runBlockingTest {
         val channel = createEndpointChannel(RecipientAddressType.PUBLIC)
-        storage.publicThirdParty.set(
-            channel.thirdPartyEndpoint.privateAddress,
-            PublicThirdPartyEndpointData(
-                channel.thirdPartyEndpoint.address,
-                channel.thirdPartyEndpoint.identityKey,
-            )
-        )
         val parcel = buildParcel(channel)
         val parcelCollection = parcel.toParcelCollection()
         val collectParcelsCall = CollectParcelsCall(Result.success(flowOf(parcelCollection)))

--- a/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
@@ -24,7 +24,7 @@ internal abstract class MockContextTestCase {
     protected val privateKeyStore: MockPrivateKeyStore = MockPrivateKeyStore()
     protected val sessionPublicKeystore: MockSessionPublicKeyStore = MockSessionPublicKeyStore()
     protected val certificateStore: MockCertificateStore = MockCertificateStore()
-    private val channelManager: ChannelManager = mock()
+    protected val channelManager: ChannelManager = mock()
 
     @Before
     fun setMockContext() {

--- a/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
@@ -7,6 +7,7 @@ import org.junit.Before
 import org.mockito.internal.util.MockUtil
 import tech.relaycorp.awaladroid.AwalaContext
 import tech.relaycorp.awaladroid.GatewayClientImpl
+import tech.relaycorp.awaladroid.endpoint.ChannelManager
 import tech.relaycorp.awaladroid.endpoint.FirstPartyEndpoint
 import tech.relaycorp.awaladroid.storage.StorageImpl
 import tech.relaycorp.awaladroid.storage.mockStorage
@@ -23,6 +24,7 @@ internal abstract class MockContextTestCase {
     protected val privateKeyStore: MockPrivateKeyStore = MockPrivateKeyStore()
     protected val sessionPublicKeystore: MockSessionPublicKeyStore = MockSessionPublicKeyStore()
     protected val certificateStore: MockCertificateStore = MockCertificateStore()
+    private val channelManager: ChannelManager = mock()
 
     @Before
     fun setMockContext() {
@@ -31,6 +33,7 @@ internal abstract class MockContextTestCase {
                 storage,
                 gatewayClient,
                 EndpointManager(privateKeyStore, sessionPublicKeystore),
+                channelManager,
                 privateKeyStore,
                 sessionPublicKeystore,
                 certificateStore,

--- a/lib/src/test/java/tech/relaycorp/awaladroid/test/ThirdPartyEndpointFactory.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/test/ThirdPartyEndpointFactory.kt
@@ -2,25 +2,18 @@ package tech.relaycorp.awaladroid.test
 
 import tech.relaycorp.awaladroid.endpoint.PrivateThirdPartyEndpoint
 import tech.relaycorp.awaladroid.endpoint.PublicThirdPartyEndpoint
-import tech.relaycorp.relaynet.ramf.RecipientAddressType
 import tech.relaycorp.relaynet.testing.pki.KeyPairSet
 import tech.relaycorp.relaynet.testing.pki.PDACertPath
 
 internal object ThirdPartyEndpointFactory {
-    fun build(type: RecipientAddressType) =
-        when (type) {
-            RecipientAddressType.PUBLIC -> buildPublic()
-            RecipientAddressType.PRIVATE -> buildPrivate()
-        }
-
     fun buildPublic(): PublicThirdPartyEndpoint = PublicThirdPartyEndpoint(
         "example.org",
         KeyPairSet.PDA_GRANTEE.public
     )
 
     fun buildPrivate(): PrivateThirdPartyEndpoint = PrivateThirdPartyEndpoint(
-        PDACertPath.PDA.subjectPrivateAddress,
-        KeyPairSet.PRIVATE_ENDPOINT.public,
+        PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress,
+        KeyPairSet.PDA_GRANTEE.public,
         PDACertPath.PDA,
         listOf(PDACertPath.PRIVATE_GW)
     )


### PR DESCRIPTION
Fixes #185. It's also worth highlighting the following:

- It introduces the instance method `FirstPartyEndpoint.authorizeIndefinitely()`, which is like `FirstPartyEndpoint.issueAuthorization()`, except that it tracks which 3rd party endpoints are authorised in order to renew their PDAs automatically.
  - For example, Awala Ping will continue to use `FirstPartyEndpoint.issueAuthorization()` but Letro will use `FirstPartyEndpoint.authorizeIndefinitely()`.
  - To stop renewing an _indefinite PDA_, it's enough to delete the respective 1st or 3rd party endpoint.
- This PR introduces the concept of "channel" (e.g., `ChannelManager`), which exists in the Awala protocol suite and refers to an established communication channel between two endpoints (which is end-to-end encrypted and where both are mutually authorised to send messages to each other).
- Because #175 isn't implemented yet, I haven't actually integrated the function to reissue+send PDAs (`FirstPartyEndpoint.reissuePDAs()`). This should be done as part of #175.
- This PR integrates `CertificationPath` from the core Awala lib, which effectively duplicates the existing `AuthorizationBundle` data class. Once this PR is merged, I'll create a separate PR to replace the remaining uses of `AuthorizationBundle`.

# Review notes

Of things that I'm likely to have got wrong here, I'd rank highly the use of `SharedPreferences` and coroutines (esp. where I have to specify a context explicitly), so please pay special attention to those.