### PR TITLE
fix(deps): bump awala from 1.65.2 to 1.66.3 && bump awala-testing from 1.5.5 to 1.5.8

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -64,10 +64,10 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
 
   // Awala
-  implementation 'tech.relaycorp:awala:1.65.2'
+  implementation 'tech.relaycorp:awala:1.66.3'
   implementation 'tech.relaycorp:awala-keystore-file:1.6.3'
   implementation 'tech.relaycorp:poweb:1.5.31'
-  testImplementation 'tech.relaycorp:awala-testing:1.5.5'
+  testImplementation 'tech.relaycorp:awala-testing:1.5.8'
 
   // Security
   implementation 'androidx.security:security-crypto:1.1.0-alpha03'

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
@@ -5,7 +5,7 @@ import java.security.PublicKey
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import tech.relaycorp.relaynet.wrappers.privateAddress
+import tech.relaycorp.relaynet.wrappers.nodeId
 
 internal class ChannelManager(
     internal val coroutineContext: CoroutineContext = Dispatchers.IO,
@@ -17,28 +17,28 @@ internal class ChannelManager(
         firstPartyEndpoint: FirstPartyEndpoint,
         thirdPartyEndpoint: ThirdPartyEndpoint
     ) {
-        create(firstPartyEndpoint, thirdPartyEndpoint.privateAddress)
+        create(firstPartyEndpoint, thirdPartyEndpoint.nodeId)
     }
 
     suspend fun create(
         firstPartyEndpoint: FirstPartyEndpoint,
         thirdPartyEndpointPublicKey: PublicKey
     ) {
-        create(firstPartyEndpoint, thirdPartyEndpointPublicKey.privateAddress)
+        create(firstPartyEndpoint, thirdPartyEndpointPublicKey.nodeId)
     }
 
     private suspend fun create(
         firstPartyEndpoint: FirstPartyEndpoint,
-        thirdPartyEndpointPrivateAddress: String
+        thirdPartyEndpointNodeId: String
     ) {
         withContext(coroutineContext) {
             val originalValue =
-                sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+                sharedPreferences.getStringSet(firstPartyEndpoint.nodeId, null)
                     ?: emptySet()
             with(sharedPreferences.edit()) {
                 putStringSet(
-                    firstPartyEndpoint.privateAddress,
-                    originalValue + mutableListOf(thirdPartyEndpointPrivateAddress)
+                    firstPartyEndpoint.nodeId,
+                    originalValue + mutableListOf(thirdPartyEndpointNodeId)
                 )
                 commit()
             }
@@ -50,7 +50,7 @@ internal class ChannelManager(
     ) {
         withContext(coroutineContext) {
             with(sharedPreferences.edit()) {
-                remove(firstPartyEndpoint.privateAddress)
+                remove(firstPartyEndpoint.nodeId)
                 commit()
             }
         }
@@ -70,8 +70,8 @@ internal class ChannelManager(
                     return@forEach
                 }
 
-                if ((value).contains(thirdPartyEndpoint.privateAddress)) {
-                    val newValue = sanitizedValue.filter { it != thirdPartyEndpoint.privateAddress }
+                if ((value).contains(thirdPartyEndpoint.nodeId)) {
+                    val newValue = sanitizedValue.filter { it != thirdPartyEndpoint.nodeId }
                     with(sharedPreferences.edit()) {
                         putStringSet(key, newValue.toMutableSet())
                         commit()
@@ -84,7 +84,7 @@ internal class ChannelManager(
     suspend fun getLinkedEndpointAddresses(firstPartyEndpoint: FirstPartyEndpoint): Set<String> =
         withContext(coroutineContext) {
             return@withContext sharedPreferences.getStringSet(
-                firstPartyEndpoint.privateAddress,
+                firstPartyEndpoint.nodeId,
                 emptySet()
             ) ?: emptySet()
         }

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/Endpoint.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/Endpoint.kt
@@ -3,11 +3,4 @@ package tech.relaycorp.awaladroid.endpoint
 /**
  * Awala endpoint.
  */
-public abstract class Endpoint(public val privateAddress: String) {
-    /**
-     * The private or public address of a private or public endpoint, respectively.
-     *
-     * This is the same as [privateAddress] if the endpoint is private.
-     */
-    public abstract val address: String
-}
+public abstract class Endpoint(public val nodeId: String)

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpoint.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpoint.kt
@@ -234,22 +234,26 @@ internal constructor(
                 throw PersistenceException("Failed to save identity key", exc)
             }
 
-            val gatewayPrivateAddress = registration.gatewayCertificate.subjectId
+            val gatewayId = registration.gatewayCertificate.subjectId
             try {
                 context.certificateStore.save(
                     CertificationPath(
                         registration.privateNodeCertificate,
                         listOf(registration.gatewayCertificate),
                     ),
-                    gatewayPrivateAddress
+                    gatewayId
                 )
             } catch (exc: KeyStoreBackendException) {
                 throw PersistenceException("Failed to save certificate", exc)
             }
 
-            context.storage.gatewayPrivateAddress.set(
+            context.storage.gatewayId.set(
                 endpoint.nodeId,
-                gatewayPrivateAddress,
+                gatewayId,
+            )
+
+            context.storage.internetAddress.set(
+                registration.gatewayInternetAddress
             )
 
             return endpoint
@@ -268,11 +272,11 @@ internal constructor(
             } catch (exc: KeyStoreBackendException) {
                 throw PersistenceException("Failed to load private key of endpoint", exc)
             }
-            val gatewayPrivateAddress = context.storage.gatewayPrivateAddress.get(nodeId)
+            val gatewayNodeId = context.storage.gatewayId.get(nodeId)
                 ?: throw PersistenceException("Failed to load gateway address for endpoint")
             val certificatePath = try {
                 context.certificateStore.retrieveLatest(
-                    nodeId, gatewayPrivateAddress
+                    nodeId, gatewayNodeId
                 )
                     ?: return null
             } catch (exc: KeyStoreBackendException) {

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpoint.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpoint.kt
@@ -20,7 +20,7 @@ import tech.relaycorp.relaynet.pki.CertificationPath
 import tech.relaycorp.relaynet.wrappers.KeyException
 import tech.relaycorp.relaynet.wrappers.deserializeRSAPublicKey
 import tech.relaycorp.relaynet.wrappers.generateRSAKeyPair
-import tech.relaycorp.relaynet.wrappers.privateAddress
+import tech.relaycorp.relaynet.wrappers.nodeId
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 import tech.relaycorp.relaynet.wrappers.x509.CertificateException
 
@@ -32,9 +32,7 @@ internal constructor(
     internal val identityPrivateKey: PrivateKey,
     internal val identityCertificate: Certificate,
     internal val identityCertificateChain: List<Certificate>,
-) : Endpoint(identityPrivateKey.privateAddress) {
-
-    public override val address: String get() = privateAddress
+) : Endpoint(identityPrivateKey.nodeId) {
 
     /**
      * The RSA public key of the endpoint.
@@ -153,14 +151,14 @@ internal constructor(
             listOf(registration.gatewayCertificate)
         )
 
-        val gatewayPrivateAddress = registration.gatewayCertificate.subjectPrivateAddress
+        val gatewayId = registration.gatewayCertificate.subjectId
         try {
             context.certificateStore.save(
                 CertificationPath(
                     registration.privateNodeCertificate,
                     listOf(registration.gatewayCertificate),
                 ),
-                gatewayPrivateAddress,
+                gatewayId,
             )
         } catch (exc: KeyStoreBackendException) {
             throw PersistenceException("Failed to save certificate", exc)
@@ -174,7 +172,7 @@ internal constructor(
         val thirdPartyEndpointAddresses = context.channelManager.getLinkedEndpointAddresses(this)
         thirdPartyEndpointAddresses.forEach { thirdPartyEndpointAddress ->
             val thirdPartyEndpoint = ThirdPartyEndpoint.load(
-                this@FirstPartyEndpoint.privateAddress,
+                this@FirstPartyEndpoint.nodeId,
                 thirdPartyEndpointAddress
             )
             if (thirdPartyEndpoint == null) {
@@ -202,8 +200,8 @@ internal constructor(
     @Throws(PersistenceException::class, SetupPendingException::class)
     public suspend fun delete() {
         val context = Awala.getContextOrThrow()
-        context.privateKeyStore.deleteKeys(privateAddress)
-        context.certificateStore.delete(privateAddress, identityCertificate.issuerCommonName)
+        context.privateKeyStore.deleteKeys(nodeId)
+        context.certificateStore.delete(nodeId, identityCertificate.issuerCommonName)
         context.channelManager.delete(this)
     }
 
@@ -236,7 +234,7 @@ internal constructor(
                 throw PersistenceException("Failed to save identity key", exc)
             }
 
-            val gatewayPrivateAddress = registration.gatewayCertificate.subjectPrivateAddress
+            val gatewayPrivateAddress = registration.gatewayCertificate.subjectId
             try {
                 context.certificateStore.save(
                     CertificationPath(
@@ -250,7 +248,7 @@ internal constructor(
             }
 
             context.storage.gatewayPrivateAddress.set(
-                endpoint.privateAddress,
+                endpoint.nodeId,
                 gatewayPrivateAddress,
             )
 
@@ -261,20 +259,20 @@ internal constructor(
          * Load an endpoint by its address.
          */
         @Throws(PersistenceException::class, SetupPendingException::class)
-        public suspend fun load(privateAddress: String): FirstPartyEndpoint? {
+        public suspend fun load(nodeId: String): FirstPartyEndpoint? {
             val context = Awala.getContextOrThrow()
             val identityPrivateKey = try {
-                context.privateKeyStore.retrieveIdentityKey(privateAddress)
+                context.privateKeyStore.retrieveIdentityKey(nodeId)
             } catch (exc: MissingKeyException) {
                 return null
             } catch (exc: KeyStoreBackendException) {
                 throw PersistenceException("Failed to load private key of endpoint", exc)
             }
-            val gatewayPrivateAddress = context.storage.gatewayPrivateAddress.get(privateAddress)
+            val gatewayPrivateAddress = context.storage.gatewayPrivateAddress.get(nodeId)
                 ?: throw PersistenceException("Failed to load gateway address for endpoint")
             val certificatePath = try {
                 context.certificateStore.retrieveLatest(
-                    privateAddress, gatewayPrivateAddress
+                    nodeId, gatewayPrivateAddress
                 )
                     ?: return null
             } catch (exc: KeyStoreBackendException) {

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/HandleGatewayCertificateChange.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/HandleGatewayCertificateChange.kt
@@ -1,7 +1,7 @@
 package tech.relaycorp.awaladroid.endpoint
 
 import tech.relaycorp.relaynet.keystores.PrivateKeyStore
-import tech.relaycorp.relaynet.wrappers.privateAddress
+import tech.relaycorp.relaynet.wrappers.nodeId
 
 internal class HandleGatewayCertificateChange(
     private val privateKeyStore: PrivateKeyStore
@@ -9,7 +9,7 @@ internal class HandleGatewayCertificateChange(
 
     suspend operator fun invoke() {
         privateKeyStore.retrieveAllIdentityKeys()
-            .mapNotNull { FirstPartyEndpoint.load(it.privateAddress) }
+            .mapNotNull { FirstPartyEndpoint.load(it.nodeId) }
             .forEach {
                 it.reRegister()
                 it.reissuePDAs()

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointData.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointData.kt
@@ -11,7 +11,7 @@ import tech.relaycorp.awaladroid.storage.persistence.PersistenceException
 import tech.relaycorp.relaynet.wrappers.deserializeRSAPublicKey
 
 internal data class PublicThirdPartyEndpointData(
-    val publicAddress: String,
+    val internetAddress: String,
     val identityKey: PublicKey,
 ) {
     @Throws(PersistenceException::class)
@@ -20,7 +20,7 @@ internal data class PublicThirdPartyEndpointData(
             BasicOutputBuffer().use { output ->
                 BsonBinaryWriter(output).use { w ->
                     w.writeStartDocument()
-                    w.writeString("public_address", publicAddress)
+                    w.writeString("internet_address", internetAddress)
                     w.writeBinaryData(
                         "identity_key",
                         BsonBinary(identityKey.encoded)
@@ -40,7 +40,7 @@ internal data class PublicThirdPartyEndpointData(
                 BsonBinaryReader(ByteBuffer.wrap(byteArray)).use { r ->
                     r.readStartDocument()
                     PublicThirdPartyEndpointData(
-                        r.readString("public_address"),
+                        r.readString("internet_address"),
                         r.readBinaryData("identity_key").data.deserializeRSAPublicKey()
                     ).also {
                         r.readEndDocument()

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/RenewExpiringCertificates.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/RenewExpiringCertificates.kt
@@ -3,7 +3,7 @@ package tech.relaycorp.awaladroid.endpoint
 import java.time.ZonedDateTime
 import kotlin.time.Duration.Companion.days
 import tech.relaycorp.relaynet.keystores.PrivateKeyStore
-import tech.relaycorp.relaynet.wrappers.privateAddress
+import tech.relaycorp.relaynet.wrappers.nodeId
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 
 internal class RenewExpiringCertificates(
@@ -13,7 +13,7 @@ internal class RenewExpiringCertificates(
 
     suspend operator fun invoke() {
         privateKeyStore.retrieveAllIdentityKeys()
-            .mapNotNull { firstPartyEndpointLoader(it.privateAddress) }
+            .mapNotNull { firstPartyEndpointLoader(it.nodeId) }
             .forEach {
                 if (it.identityCertificate.isExpiring) {
                     it.reRegister()

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ThirdPartyEndpoint.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ThirdPartyEndpoint.kt
@@ -6,14 +6,14 @@ import tech.relaycorp.awaladroid.AwaladroidException
 import tech.relaycorp.awaladroid.SetupPendingException
 import tech.relaycorp.awaladroid.storage.persistence.PersistenceException
 import tech.relaycorp.relaynet.InvalidNodeConnectionParams
-import tech.relaycorp.relaynet.PublicNodeConnectionParams
+import tech.relaycorp.relaynet.NodeConnectionParams
 import tech.relaycorp.relaynet.SessionKey
 import tech.relaycorp.relaynet.keystores.MissingKeyException
 import tech.relaycorp.relaynet.pki.CertificationPath
 import tech.relaycorp.relaynet.pki.CertificationPathException
 import tech.relaycorp.relaynet.wrappers.KeyException
 import tech.relaycorp.relaynet.wrappers.deserializeRSAPublicKey
-import tech.relaycorp.relaynet.wrappers.privateAddress
+import tech.relaycorp.relaynet.wrappers.nodeId
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 
 /**
@@ -21,7 +21,7 @@ import tech.relaycorp.relaynet.wrappers.x509.Certificate
  */
 public sealed class ThirdPartyEndpoint(
     internal val identityKey: PublicKey
-) : Endpoint(identityKey.privateAddress) {
+) : Endpoint(identityKey.nodeId) {
 
     /**
      * Delete the endpoint.
@@ -29,8 +29,8 @@ public sealed class ThirdPartyEndpoint(
     @Throws(PersistenceException::class)
     public open suspend fun delete() {
         val context = Awala.getContextOrThrow()
-        context.privateKeyStore.deleteSessionKeysForPeer(privateAddress)
-        context.sessionPublicKeyStore.delete(privateAddress)
+        context.privateKeyStore.deleteSessionKeysForPeer(nodeId)
+        context.sessionPublicKeyStore.delete(nodeId)
         context.channelManager.delete(this)
     }
 
@@ -38,10 +38,10 @@ public sealed class ThirdPartyEndpoint(
         @Throws(PersistenceException::class)
         internal suspend fun load(
             firstPartyAddress: String,
-            thirdPartyPrivateAddress: String
+            thirdPartyId: String
         ): ThirdPartyEndpoint? =
-            PublicThirdPartyEndpoint.load(thirdPartyPrivateAddress)
-                ?: PrivateThirdPartyEndpoint.load(thirdPartyPrivateAddress, firstPartyAddress)
+            PublicThirdPartyEndpoint.load(thirdPartyId)
+                ?: PrivateThirdPartyEndpoint.load(thirdPartyId, firstPartyAddress)
     }
 }
 
@@ -58,8 +58,7 @@ public class PrivateThirdPartyEndpoint internal constructor(
     internal val pdaChain: List<Certificate>
 ) : ThirdPartyEndpoint(identityKey) {
 
-    override val address: String get() = privateAddress
-    private val storageKey = "${firstPartyEndpointAddress}_$privateAddress"
+    private val storageKey = "${firstPartyEndpointAddress}_$nodeId"
 
     @Throws(PersistenceException::class, SetupPendingException::class)
     override suspend fun delete() {
@@ -76,15 +75,15 @@ public class PrivateThirdPartyEndpoint internal constructor(
             throw InvalidAuthorizationException("PDA path is invalid", exc)
         }
 
-        val pdaSubjectAddress = pdaPath.leafCertificate.subjectPrivateAddress
+        val pdaSubjectAddress = pdaPath.leafCertificate.subjectId
         if (pdaSubjectAddress != firstPartyEndpointAddress) {
             throw InvalidAuthorizationException(
                 "PDA subject ($pdaSubjectAddress) is not first-party endpoint"
             )
         }
 
-        val pdaIssuerAddress = pdaPath.certificateAuthorities.first().subjectPrivateAddress
-        if (pdaIssuerAddress != privateAddress) {
+        val pdaIssuerAddress = pdaPath.certificateAuthorities.first().subjectId
+        if (pdaIssuerAddress != nodeId) {
             throw InvalidAuthorizationException(
                 "PDA issuer ($pdaIssuerAddress) is not third-party endpoint"
             )
@@ -152,7 +151,7 @@ public class PrivateThirdPartyEndpoint internal constructor(
             val pda = pdaPath.leafCertificate
             val pdaChain = pdaPath.certificateAuthorities
 
-            val firstPartyAddress = pda.subjectPrivateAddress
+            val firstPartyAddress = pda.subjectId
             try {
                 context.privateKeyStore.retrieveIdentityKey(firstPartyAddress)
             } catch (exc: MissingKeyException) {
@@ -179,7 +178,7 @@ public class PrivateThirdPartyEndpoint internal constructor(
                 PrivateThirdPartyEndpointData(identityKey, pdaPath)
             )
 
-            context.sessionPublicKeyStore.save(sessionKey, endpoint.privateAddress)
+            context.sessionPublicKeyStore.save(sessionKey, endpoint.nodeId)
 
             return endpoint
         }
@@ -189,19 +188,17 @@ public class PrivateThirdPartyEndpoint internal constructor(
 /**
  * A public third-party endpoint (i.e., an Internet host in a centralized service).
  *
- * @property publicAddress The public address of the endpoint (e.g., "ping.awala.services").
+ * @property internetAddress The public address of the endpoint (e.g., "ping.awala.services").
  */
 public class PublicThirdPartyEndpoint internal constructor(
-    public val publicAddress: String,
+    public val internetAddress: String,
     identityKey: PublicKey
 ) : ThirdPartyEndpoint(identityKey) {
-
-    override val address: String get() = "https://$publicAddress"
 
     @Throws(PersistenceException::class, SetupPendingException::class)
     override suspend fun delete() {
         val context = Awala.getContextOrThrow()
-        context.storage.publicThirdParty.delete(privateAddress)
+        context.storage.publicThirdParty.delete(nodeId)
         super.delete()
     }
 
@@ -213,7 +210,7 @@ public class PublicThirdPartyEndpoint internal constructor(
         public suspend fun load(privateAddress: String): PublicThirdPartyEndpoint? {
             val storage = Awala.getContextOrThrow().storage
             return storage.publicThirdParty.get(privateAddress)?.let {
-                PublicThirdPartyEndpoint(it.publicAddress, it.identityKey)
+                PublicThirdPartyEndpoint(it.internetAddress, it.identityKey)
             }
         }
 
@@ -232,18 +229,18 @@ public class PublicThirdPartyEndpoint internal constructor(
         ): PublicThirdPartyEndpoint {
             val context = Awala.getContextOrThrow()
             val connectionParams = try {
-                PublicNodeConnectionParams.deserialize(connectionParamsSerialized)
+                NodeConnectionParams.deserialize(connectionParamsSerialized)
             } catch (exc: InvalidNodeConnectionParams) {
                 throw InvalidThirdPartyEndpoint(
                     "Connection params serialization is malformed",
                     exc,
                 )
             }
-            val peerPrivateAddress = connectionParams.identityKey.privateAddress
+            val peerPrivateAddress = connectionParams.identityKey.nodeId
             context.storage.publicThirdParty.set(
                 peerPrivateAddress,
                 PublicThirdPartyEndpointData(
-                    connectionParams.publicAddress,
+                    connectionParams.internetAddress,
                     connectionParams.identityKey
                 )
             )
@@ -252,7 +249,7 @@ public class PublicThirdPartyEndpoint internal constructor(
                 peerPrivateAddress,
             )
             return PublicThirdPartyEndpoint(
-                connectionParams.publicAddress,
+                connectionParams.internetAddress,
                 connectionParams.identityKey,
             )
         }

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ThirdPartyEndpoint.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ThirdPartyEndpoint.kt
@@ -48,7 +48,7 @@ public sealed class ThirdPartyEndpoint(
 /**
  * A private third-party endpoint (i.e., one behind a different private gateway).
  *
- * @property firstPartyEndpointAddress The private address of the first-party endpoint linked to
+ * @property firstPartyEndpointAddress The nodeId of the first-party endpoint linked to
  * this endpoint.
  */
 public class PrivateThirdPartyEndpoint internal constructor(
@@ -204,12 +204,12 @@ public class PublicThirdPartyEndpoint internal constructor(
 
     public companion object {
         /**
-         * Load an endpoint by its [privateAddress].
+         * Load an endpoint by its [nodeId].
          */
         @Throws(PersistenceException::class, SetupPendingException::class)
-        public suspend fun load(privateAddress: String): PublicThirdPartyEndpoint? {
+        public suspend fun load(nodeId: String): PublicThirdPartyEndpoint? {
             val storage = Awala.getContextOrThrow().storage
-            return storage.publicThirdParty.get(privateAddress)?.let {
+            return storage.publicThirdParty.get(nodeId)?.let {
                 PublicThirdPartyEndpoint(it.internetAddress, it.identityKey)
             }
         }
@@ -236,9 +236,9 @@ public class PublicThirdPartyEndpoint internal constructor(
                     exc,
                 )
             }
-            val peerPrivateAddress = connectionParams.identityKey.nodeId
+            val peerNodeId = connectionParams.identityKey.nodeId
             context.storage.publicThirdParty.set(
-                peerPrivateAddress,
+                peerNodeId,
                 PublicThirdPartyEndpointData(
                     connectionParams.internetAddress,
                     connectionParams.identityKey
@@ -246,7 +246,7 @@ public class PublicThirdPartyEndpoint internal constructor(
             )
             context.sessionPublicKeyStore.save(
                 connectionParams.sessionKey,
-                peerPrivateAddress,
+                peerNodeId,
             )
             return PublicThirdPartyEndpoint(
                 connectionParams.internetAddress,

--- a/lib/src/main/java/tech/relaycorp/awaladroid/messaging/IncomingMessage.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/messaging/IncomingMessage.kt
@@ -48,18 +48,18 @@ public class IncomingMessage internal constructor(
             SetupPendingException::class,
         )
         internal suspend fun build(parcel: Parcel, ack: suspend () -> Unit): IncomingMessage? {
-            val recipientEndpoint = FirstPartyEndpoint.load(parcel.recipientAddress)
+            val recipientEndpoint = FirstPartyEndpoint.load(parcel.recipient.id)
                 ?: throw UnknownFirstPartyEndpointException(
-                    "Unknown first-party endpoint ${parcel.recipientAddress}"
+                    "Unknown first-party endpoint ${parcel.recipient.id}"
                 )
 
             val sender = ThirdPartyEndpoint.load(
-                parcel.recipientAddress,
-                parcel.senderCertificate.subjectPrivateAddress,
+                parcel.recipient.id,
+                parcel.senderCertificate.subjectId,
             ) ?: throw UnknownThirdPartyEndpointException(
                 "Unknown third-party endpoint " +
-                    "${parcel.senderCertificate.subjectPrivateAddress} " +
-                    "for first-party endpoint ${parcel.recipientAddress}"
+                    "${parcel.senderCertificate.subjectId} " +
+                    "for first-party endpoint ${parcel.recipient.id}"
             )
 
             val context = Awala.getContextOrThrow()
@@ -92,8 +92,8 @@ public class IncomingMessage internal constructor(
         ) {
             if (senderEndpoint is PublicThirdPartyEndpoint) {
                 logger.info(
-                    "Ignoring PDA path from public endpoint ${senderEndpoint.privateAddress} " +
-                        "(${senderEndpoint.publicAddress})"
+                    "Ignoring PDA path from public endpoint ${senderEndpoint.nodeId} " +
+                        "(${senderEndpoint.internetAddress})"
                 )
                 return
             }
@@ -102,8 +102,8 @@ public class IncomingMessage internal constructor(
             } catch (exc: CertificationPathException) {
                 logger.log(
                     Level.INFO,
-                    "Ignoring malformed PDA path for ${recipientEndpoint.privateAddress} " +
-                        "from ${senderEndpoint.privateAddress}",
+                    "Ignoring malformed PDA path for ${recipientEndpoint.nodeId} " +
+                        "from ${senderEndpoint.nodeId}",
                     exc,
                 )
                 return
@@ -114,15 +114,15 @@ public class IncomingMessage internal constructor(
             } catch (exc: InvalidAuthorizationException) {
                 logger.log(
                     Level.INFO,
-                    "Ignoring invalid PDA path for ${recipientEndpoint.privateAddress} " +
-                        "from ${senderEndpoint.privateAddress}",
+                    "Ignoring invalid PDA path for ${recipientEndpoint.nodeId} " +
+                        "from ${senderEndpoint.nodeId}",
                     exc,
                 )
                 return
             }
             logger.info(
-                "Updated PDA path from ${senderEndpoint.privateAddress} for " +
-                    recipientEndpoint.privateAddress
+                "Updated PDA path from ${senderEndpoint.nodeId} for " +
+                    recipientEndpoint.nodeId
             )
         }
     }

--- a/lib/src/main/java/tech/relaycorp/awaladroid/messaging/OutgoingMessage.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/messaging/OutgoingMessage.kt
@@ -83,7 +83,10 @@ private constructor(
             senderEndpoint.nodeId,
         )
         return Parcel(
-            recipient = Recipient(recipientEndpoint.nodeId, (recipientEndpoint as? PublicThirdPartyEndpoint)?.internetAddress),
+            recipient = Recipient(
+                recipientEndpoint.nodeId,
+                (recipientEndpoint as? PublicThirdPartyEndpoint)?.internetAddress
+            ),
             payload = payload,
             senderCertificate = getSenderCertificate(),
             messageId = parcelId.value,

--- a/lib/src/main/java/tech/relaycorp/awaladroid/messaging/OutgoingMessage.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/messaging/OutgoingMessage.kt
@@ -9,6 +9,7 @@ import tech.relaycorp.awaladroid.endpoint.PublicThirdPartyEndpoint
 import tech.relaycorp.awaladroid.endpoint.ThirdPartyEndpoint
 import tech.relaycorp.relaynet.issueEndpointCertificate
 import tech.relaycorp.relaynet.messages.Parcel
+import tech.relaycorp.relaynet.messages.Recipient
 import tech.relaycorp.relaynet.messages.payloads.ServiceMessage
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 
@@ -78,11 +79,11 @@ private constructor(
         val endpointManager = Awala.getContextOrThrow().endpointManager
         val payload = endpointManager.wrapMessagePayload(
             serviceMessage,
-            recipientEndpoint.privateAddress,
-            senderEndpoint.privateAddress,
+            recipientEndpoint.nodeId,
+            senderEndpoint.nodeId,
         )
         return Parcel(
-            recipientAddress = recipientEndpoint.address,
+            recipient = Recipient(recipientEndpoint.nodeId, (recipientEndpoint as? PublicThirdPartyEndpoint)?.internetAddress),
             payload = payload,
             senderCertificate = getSenderCertificate(),
             messageId = parcelId.value,

--- a/lib/src/main/java/tech/relaycorp/awaladroid/messaging/ReceiveMessages.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/messaging/ReceiveMessages.kt
@@ -25,7 +25,7 @@ import tech.relaycorp.relaynet.messages.InvalidMessageException
 import tech.relaycorp.relaynet.ramf.InvalidPayloadException
 import tech.relaycorp.relaynet.ramf.RAMFException
 import tech.relaycorp.relaynet.wrappers.cms.EnvelopedDataException
-import tech.relaycorp.relaynet.wrappers.privateAddress
+import tech.relaycorp.relaynet.wrappers.nodeId
 
 internal class ReceiveMessages(
     private val pdcClientBuilder: () -> PDCClient = { PoWebClient.initLocal(Awala.POWEB_PORT) }
@@ -60,7 +60,7 @@ internal class ReceiveMessages(
         val context = Awala.getContextOrThrow()
         context.privateKeyStore.retrieveAllIdentityKeys()
             .flatMap { identityPrivateKey ->
-                val privateAddress = identityPrivateKey.privateAddress
+                val privateAddress = identityPrivateKey.nodeId
                 val privateGatewayPrivateAddress =
                     context.storage.gatewayPrivateAddress.get(privateAddress)
                         ?: return@flatMap emptyList()

--- a/lib/src/main/java/tech/relaycorp/awaladroid/messaging/ReceiveMessages.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/messaging/ReceiveMessages.kt
@@ -60,13 +60,13 @@ internal class ReceiveMessages(
         val context = Awala.getContextOrThrow()
         context.privateKeyStore.retrieveAllIdentityKeys()
             .flatMap { identityPrivateKey ->
-                val privateAddress = identityPrivateKey.nodeId
-                val privateGatewayPrivateAddress =
-                    context.storage.gatewayPrivateAddress.get(privateAddress)
+                val nodeId = identityPrivateKey.nodeId
+                val privateGatewayId =
+                    context.storage.gatewayId.get(nodeId)
                         ?: return@flatMap emptyList()
                 context.certificateStore.retrieveAll(
-                    privateAddress,
-                    privateGatewayPrivateAddress
+                    nodeId,
+                    privateGatewayId
                 ).map {
                     Signer(
                         it.leafCertificate,

--- a/lib/src/main/java/tech/relaycorp/awaladroid/storage/StorageImpl.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/storage/StorageImpl.kt
@@ -25,8 +25,8 @@ constructor(
         persistence = persistence,
         prefix = "internet_address_",
         serializer = { internetAddress: String -> internetAddress.toByteArray(ascii) },
-        deserializer = {
-                internetAddressSerialized: ByteArray -> internetAddressSerialized.toString(ascii)
+        deserializer = { internetAddressSerialized: ByteArray ->
+            internetAddressSerialized.toString(ascii)
         }
     )
 

--- a/lib/src/main/java/tech/relaycorp/awaladroid/storage/StorageImpl.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/storage/StorageImpl.kt
@@ -16,7 +16,7 @@ constructor(
     private val ascii = Charset.forName("ASCII")
     internal val gatewayPrivateAddress: SingleModule<String> = SingleModule(
         persistence = persistence,
-        prefix = "gateway_private_address_",
+        prefix = "gateway_id_",
         serializer = { address: String -> address.toByteArray(ascii) },
         deserializer = { addressSerialized: ByteArray -> addressSerialized.toString(ascii) }
     )

--- a/lib/src/main/java/tech/relaycorp/awaladroid/storage/StorageImpl.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/storage/StorageImpl.kt
@@ -14,11 +14,20 @@ constructor(
 ) {
 
     private val ascii = Charset.forName("ASCII")
-    internal val gatewayPrivateAddress: SingleModule<String> = SingleModule(
+    internal val gatewayId: SingleModule<String> = SingleModule(
         persistence = persistence,
         prefix = "gateway_id_",
         serializer = { address: String -> address.toByteArray(ascii) },
         deserializer = { addressSerialized: ByteArray -> addressSerialized.toString(ascii) }
+    )
+
+    internal val internetAddress: SingleModule<String> = SingleModule(
+        persistence = persistence,
+        prefix = "internet_address_",
+        serializer = { internetAddress: String -> internetAddress.toByteArray(ascii) },
+        deserializer = {
+                internetAddressSerialized: ByteArray -> internetAddressSerialized.toString(ascii)
+        }
     )
 
     internal val publicThirdParty: Module<PublicThirdPartyEndpointData> = Module(

--- a/lib/src/test/java/tech/relaycorp/awaladroid/AndroidPrivateKeyStoreTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/AndroidPrivateKeyStoreTest.kt
@@ -18,11 +18,11 @@ public class AndroidPrivateKeyStoreTest {
         val androidContext = RuntimeEnvironment.getApplication()
         val root = FileKeystoreRoot(File(androidContext.filesDir, "tmp-keystore"))
         val store = AndroidPrivateKeyStore(root, androidContext)
-        val privateKey = KeyPairSet.PRIVATE_ENDPOINT.private
+        val id = KeyPairSet.PRIVATE_ENDPOINT.private
         val certificate = PDACertPath.PRIVATE_ENDPOINT
 
-        store.saveIdentityKey(privateKey)
-        val retrievedPrivateKey = store.retrieveIdentityKey(certificate.subjectPrivateAddress)
-        assertEquals(privateKey, retrievedPrivateKey)
+        store.saveIdentityKey(id)
+        val retrievedId = store.retrieveIdentityKey(certificate.subjectId)
+        assertEquals(id, retrievedId)
     }
 }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/AwalaTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/AwalaTest.kt
@@ -25,7 +25,7 @@ import tech.relaycorp.awaladroid.test.unsetAwalaContext
 import tech.relaycorp.relaynet.issueEndpointCertificate
 import tech.relaycorp.relaynet.pki.CertificationPath
 import tech.relaycorp.relaynet.testing.pki.KeyPairSet
-import tech.relaycorp.relaynet.wrappers.privateAddress
+import tech.relaycorp.relaynet.wrappers.nodeId
 
 @RunWith(RobolectricTestRunner::class)
 public class AwalaTest {
@@ -102,7 +102,7 @@ public class AwalaTest {
         )
         assertNotNull(
             certificateStore.retrieveLatest(
-                expiringCertificate.subjectPrivateAddress,
+                expiringCertificate.subjectId,
                 expiringCertificate.issuerCommonName,
             )
         )
@@ -113,8 +113,8 @@ public class AwalaTest {
             Awala.setUp(androidContext)
             advanceUntilIdle()
             certificateStore.retrieveLatest(
-                KeyPairSet.PRIVATE_ENDPOINT.public.privateAddress,
-                KeyPairSet.PRIVATE_GW.private.privateAddress
+                KeyPairSet.PRIVATE_ENDPOINT.public.nodeId,
+                KeyPairSet.PRIVATE_GW.private.nodeId
             ) ?: return@runTest
         }
         throw AssertionError("Expired certificate not deleted")

--- a/lib/src/test/java/tech/relaycorp/awaladroid/GatewayClientImplTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/GatewayClientImplTest.kt
@@ -31,11 +31,11 @@ import tech.relaycorp.awaladroid.messaging.SendMessage
 import tech.relaycorp.awaladroid.messaging.SendMessageException
 import tech.relaycorp.awaladroid.test.MessageFactory
 import tech.relaycorp.awaladroid.test.MockContextTestCase
+import tech.relaycorp.awaladroid.test.RecipientAddressType
 import tech.relaycorp.relaynet.bindings.pdc.ClientBindingException
 import tech.relaycorp.relaynet.bindings.pdc.ServerConnectionException
 import tech.relaycorp.relaynet.messages.control.PrivateNodeRegistration
 import tech.relaycorp.relaynet.messages.control.PrivateNodeRegistrationAuthorization
-import tech.relaycorp.relaynet.ramf.RecipientAddressType
 import tech.relaycorp.relaynet.testing.pdc.MockPDCClient
 import tech.relaycorp.relaynet.testing.pdc.RegisterNodeCall
 import tech.relaycorp.relaynet.testing.pki.KeyPairSet
@@ -104,7 +104,7 @@ internal class GatewayClientImplTest : MockContextTestCase() {
             it.getArgument<((Message) -> Unit)?>(1)(replyMessage)
         }
 
-        val pnr = PrivateNodeRegistration(PDACertPath.PRIVATE_ENDPOINT, PDACertPath.PRIVATE_GW)
+        val pnr = PrivateNodeRegistration(PDACertPath.PRIVATE_ENDPOINT, PDACertPath.PRIVATE_GW, "")
         pdcClient = MockPDCClient(RegisterNodeCall(Result.success(pnr)))
 
         val result = gatewayClient.registerEndpoint(KeyPairSet.PRIVATE_ENDPOINT)

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
@@ -42,15 +42,15 @@ internal class ChannelManagerTest {
     fun create_non_existing() = runTest {
         assertEquals(
             null,
-            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+            sharedPreferences.getStringSet(firstPartyEndpoint.nodeId, null)
         )
         val manager = ChannelManager(coroutineContext) { sharedPreferences }
 
         manager.create(firstPartyEndpoint, thirdPartyEndpoint)
 
         assertEquals(
-            setOf(thirdPartyEndpoint.privateAddress),
-            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+            setOf(thirdPartyEndpoint.nodeId),
+            sharedPreferences.getStringSet(firstPartyEndpoint.nodeId, null)
         )
     }
 
@@ -62,8 +62,8 @@ internal class ChannelManagerTest {
         manager.create(firstPartyEndpoint, thirdPartyEndpoint)
 
         assertEquals(
-            setOf(thirdPartyEndpoint.privateAddress),
-            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+            setOf(thirdPartyEndpoint.nodeId),
+            sharedPreferences.getStringSet(firstPartyEndpoint.nodeId, null)
         )
     }
 
@@ -75,8 +75,8 @@ internal class ChannelManagerTest {
         manager.create(firstPartyEndpoint, thirdPartyEndpoint)
 
         assertEquals(
-            setOf(thirdPartyEndpoint.privateAddress),
-            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+            setOf(thirdPartyEndpoint.nodeId),
+            sharedPreferences.getStringSet(firstPartyEndpoint.nodeId, null)
         )
     }
 
@@ -88,7 +88,7 @@ internal class ChannelManagerTest {
 
         assertEquals(
             null,
-            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+            sharedPreferences.getStringSet(firstPartyEndpoint.nodeId, null)
         )
     }
 
@@ -101,7 +101,7 @@ internal class ChannelManagerTest {
 
         assertEquals(
             null,
-            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+            sharedPreferences.getStringSet(firstPartyEndpoint.nodeId, null)
         )
     }
 
@@ -111,7 +111,7 @@ internal class ChannelManagerTest {
         val unrelatedThirdPartyEndpointAddress = "i-have-nothing-to-do-with-the-other"
         with(sharedPreferences.edit()) {
             putStringSet(
-                firstPartyEndpoint.privateAddress,
+                firstPartyEndpoint.nodeId,
                 mutableSetOf(unrelatedThirdPartyEndpointAddress)
             )
             apply()
@@ -121,7 +121,7 @@ internal class ChannelManagerTest {
 
         assertEquals(
             mutableSetOf(unrelatedThirdPartyEndpointAddress),
-            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+            sharedPreferences.getStringSet(firstPartyEndpoint.nodeId, null)
         )
     }
 
@@ -131,8 +131,8 @@ internal class ChannelManagerTest {
         val unrelatedThirdPartyEndpointAddress = "i-have-nothing-to-do-with-the-other"
         with(sharedPreferences.edit()) {
             putStringSet(
-                firstPartyEndpoint.privateAddress,
-                mutableSetOf(unrelatedThirdPartyEndpointAddress, thirdPartyEndpoint.privateAddress)
+                firstPartyEndpoint.nodeId,
+                mutableSetOf(unrelatedThirdPartyEndpointAddress, thirdPartyEndpoint.nodeId)
             )
             apply()
         }
@@ -141,7 +141,7 @@ internal class ChannelManagerTest {
 
         assertEquals(
             setOf(unrelatedThirdPartyEndpointAddress),
-            sharedPreferences.getStringSet(firstPartyEndpoint.privateAddress, null)
+            sharedPreferences.getStringSet(firstPartyEndpoint.nodeId, null)
         )
     }
 
@@ -151,7 +151,7 @@ internal class ChannelManagerTest {
         val malformedValue = "i-should-not-be-here"
         with(sharedPreferences.edit()) {
             putString(
-                firstPartyEndpoint.privateAddress,
+                firstPartyEndpoint.nodeId,
                 malformedValue
             )
             apply()
@@ -161,7 +161,7 @@ internal class ChannelManagerTest {
 
         assertEquals(
             malformedValue,
-            sharedPreferences.getString(firstPartyEndpoint.privateAddress, null)
+            sharedPreferences.getString(firstPartyEndpoint.nodeId, null)
         )
     }
 
@@ -171,7 +171,7 @@ internal class ChannelManagerTest {
         val malformedValue = 42
         with(sharedPreferences.edit()) {
             putInt(
-                firstPartyEndpoint.privateAddress,
+                firstPartyEndpoint.nodeId,
                 malformedValue
             )
             apply()
@@ -181,7 +181,7 @@ internal class ChannelManagerTest {
 
         assertEquals(
             malformedValue,
-            sharedPreferences.getInt(firstPartyEndpoint.privateAddress, 0)
+            sharedPreferences.getInt(firstPartyEndpoint.nodeId, 0)
         )
     }
 
@@ -201,6 +201,6 @@ internal class ChannelManagerTest {
 
         val linkedEndpoints = manager.getLinkedEndpointAddresses(firstPartyEndpoint)
 
-        assertEquals(setOf(thirdPartyEndpoint.privateAddress), linkedEndpoints)
+        assertEquals(setOf(thirdPartyEndpoint.nodeId), linkedEndpoints)
     }
 }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpointTest.kt
@@ -65,11 +65,12 @@ internal class FirstPartyEndpointTest : MockContextTestCase() {
 
     @Test
     fun register() = runTest {
+        val gatewayInternetAddress = "example.org"
         whenever(gatewayClient.registerEndpoint(any())).thenReturn(
             PrivateNodeRegistration(
                 PDACertPath.PRIVATE_ENDPOINT,
                 PDACertPath.PRIVATE_GW,
-                ""
+                gatewayInternetAddress
             )
         )
 
@@ -83,10 +84,11 @@ internal class FirstPartyEndpointTest : MockContextTestCase() {
             PDACertPath.PRIVATE_GW.subjectId
         )
         assertEquals(PDACertPath.PRIVATE_ENDPOINT, identityCertificatePath!!.leafCertificate)
-        verify(storage.gatewayPrivateAddress).set(
+        verify(storage.gatewayId).set(
             endpoint.nodeId,
             PDACertPath.PRIVATE_GW.subjectId
         )
+        verify(storage.internetAddress).set(gatewayInternetAddress)
     }
 
     @Test
@@ -205,7 +207,7 @@ internal class FirstPartyEndpointTest : MockContextTestCase() {
 
     @Test
     fun load_withMissingPrivateKey() = runTest {
-        whenever(storage.gatewayPrivateAddress.get())
+        whenever(storage.gatewayId.get())
             .thenReturn(PDACertPath.PRIVATE_GW.subjectId)
 
         assertNull(FirstPartyEndpoint.load("non-existent"))
@@ -218,7 +220,7 @@ internal class FirstPartyEndpointTest : MockContextTestCase() {
                 privateKeyStore = MockPrivateKeyStore(retrievalException = Exception("Oh noes"))
             )
         )
-        whenever(storage.gatewayPrivateAddress.get())
+        whenever(storage.gatewayId.get())
             .thenReturn(PDACertPath.PRIVATE_GW.subjectId)
 
         try {
@@ -233,9 +235,9 @@ internal class FirstPartyEndpointTest : MockContextTestCase() {
     }
 
     @Test
-    fun load_withMissingGatewayPrivateAddress(): Unit = runTest {
+    fun load_withMissingGatewayId(): Unit = runTest {
         val firstPartyEndpoint = createFirstPartyEndpoint()
-        whenever(storage.gatewayPrivateAddress.get(firstPartyEndpoint.nodeId))
+        whenever(storage.gatewayId.get(firstPartyEndpoint.nodeId))
             .thenReturn(null)
 
         try {

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpointTest.kt
@@ -26,9 +26,9 @@ import tech.relaycorp.awaladroid.RegistrationFailedException
 import tech.relaycorp.awaladroid.common.toPublicKey
 import tech.relaycorp.awaladroid.messaging.OutgoingMessage
 import tech.relaycorp.awaladroid.storage.persistence.PersistenceException
-import tech.relaycorp.awaladroid.test.*
 import tech.relaycorp.awaladroid.test.FirstPartyEndpointFactory
 import tech.relaycorp.awaladroid.test.MockContextTestCase
+import tech.relaycorp.awaladroid.test.RecipientAddressType
 import tech.relaycorp.awaladroid.test.ThirdPartyEndpointFactory
 import tech.relaycorp.awaladroid.test.assertSameDateTime
 import tech.relaycorp.awaladroid.test.setAwalaContext

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointTest.kt
@@ -21,7 +21,7 @@ internal class PublicThirdPartyEndpointTest : MockContextTestCase() {
     private val internetAddress = "example.org"
 
     @Test
-    fun privateAddress() {
+    fun nodeId() {
         val identityKey = KeyPairSet.PDA_GRANTEE.public
         val thirdPartyEndpoint = PublicThirdPartyEndpoint(
             internetAddress,
@@ -33,7 +33,7 @@ internal class PublicThirdPartyEndpointTest : MockContextTestCase() {
 
     @Test
     fun load_successful() = runTest {
-        val privateAddress = UUID.randomUUID().toString()
+        val id = UUID.randomUUID().toString()
         whenever(storage.publicThirdParty.get(any()))
             .thenReturn(
                 PublicThirdPartyEndpointData(
@@ -42,7 +42,7 @@ internal class PublicThirdPartyEndpointTest : MockContextTestCase() {
                 )
             )
 
-        val endpoint = PublicThirdPartyEndpoint.load(privateAddress)!!
+        val endpoint = PublicThirdPartyEndpoint.load(id)!!
         assertEquals(internetAddress, endpoint.internetAddress)
         assertEquals(KeyPairSet.PDA_GRANTEE.public, endpoint.identityKey)
     }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointTest.kt
@@ -11,44 +11,34 @@ import org.junit.Test
 import tech.relaycorp.awaladroid.test.FirstPartyEndpointFactory
 import tech.relaycorp.awaladroid.test.MockContextTestCase
 import tech.relaycorp.awaladroid.test.ThirdPartyEndpointFactory
-import tech.relaycorp.relaynet.PublicNodeConnectionParams
+import tech.relaycorp.relaynet.NodeConnectionParams
 import tech.relaycorp.relaynet.SessionKeyPair
 import tech.relaycorp.relaynet.testing.pki.KeyPairSet
 import tech.relaycorp.relaynet.testing.pki.PDACertPath
-import tech.relaycorp.relaynet.wrappers.privateAddress
+import tech.relaycorp.relaynet.wrappers.nodeId
 
 internal class PublicThirdPartyEndpointTest : MockContextTestCase() {
-    private val publicAddress = "example.org"
+    private val internetAddress = "example.org"
 
     @Test
     fun privateAddress() {
         val identityKey = KeyPairSet.PDA_GRANTEE.public
         val thirdPartyEndpoint = PublicThirdPartyEndpoint(
-            publicAddress,
+            internetAddress,
             identityKey,
         )
 
-        assertEquals(identityKey.privateAddress, thirdPartyEndpoint.privateAddress)
-    }
-
-    @Test
-    fun address() {
-        val thirdPartyEndpoint = PublicThirdPartyEndpoint(
-            publicAddress,
-            KeyPairSet.PDA_GRANTEE.public,
-        )
-
-        assertEquals("https://$publicAddress", thirdPartyEndpoint.address)
+        assertEquals(identityKey.nodeId, thirdPartyEndpoint.nodeId)
     }
 
     @Test
     fun load_successful() = runTest {
         val privateAddress = UUID.randomUUID().toString()
         whenever(storage.publicThirdParty.get(any()))
-            .thenReturn(PublicThirdPartyEndpointData(publicAddress, KeyPairSet.PDA_GRANTEE.public))
+            .thenReturn(PublicThirdPartyEndpointData(internetAddress, KeyPairSet.PDA_GRANTEE.public))
 
         val endpoint = PublicThirdPartyEndpoint.load(privateAddress)!!
-        assertEquals(publicAddress, endpoint.publicAddress)
+        assertEquals(internetAddress, endpoint.internetAddress)
         assertEquals(KeyPairSet.PDA_GRANTEE.public, endpoint.identityKey)
     }
 
@@ -61,24 +51,24 @@ internal class PublicThirdPartyEndpointTest : MockContextTestCase() {
 
     @Test
     fun import_validConnectionParams() = runTest {
-        val connectionParams = PublicNodeConnectionParams(
-            publicAddress,
+        val connectionParams = NodeConnectionParams(
+            internetAddress,
             KeyPairSet.PDA_GRANTEE.public,
             SessionKeyPair.generate().sessionKey
         )
 
         val thirdPartyEndpoint = PublicThirdPartyEndpoint.import(connectionParams.serialize())
 
-        assertEquals(connectionParams.publicAddress, thirdPartyEndpoint.publicAddress)
+        assertEquals(connectionParams.internetAddress, thirdPartyEndpoint.internetAddress)
         assertEquals(connectionParams.identityKey, thirdPartyEndpoint.identityKey)
         verify(storage.publicThirdParty).set(
-            PDACertPath.PDA.subjectPrivateAddress,
+            PDACertPath.PDA.subjectId,
             PublicThirdPartyEndpointData(
-                connectionParams.publicAddress,
+                connectionParams.internetAddress,
                 connectionParams.identityKey
             )
         )
-        sessionPublicKeystore.retrieve(thirdPartyEndpoint.privateAddress)
+        sessionPublicKeystore.retrieve(thirdPartyEndpoint.nodeId)
     }
 
     @Test
@@ -100,10 +90,10 @@ internal class PublicThirdPartyEndpointTest : MockContextTestCase() {
     fun dataSerialization() {
         val identityKey = KeyPairSet.PDA_GRANTEE.public
 
-        val dataSerialized = PublicThirdPartyEndpointData(publicAddress, identityKey).serialize()
+        val dataSerialized = PublicThirdPartyEndpointData(internetAddress, identityKey).serialize()
         val data = PublicThirdPartyEndpointData.deserialize(dataSerialized)
 
-        assertEquals(publicAddress, data.publicAddress)
+        assertEquals(internetAddress, data.internetAddress)
         assertEquals(identityKey, data.identityKey)
     }
 
@@ -115,16 +105,16 @@ internal class PublicThirdPartyEndpointTest : MockContextTestCase() {
         privateKeyStore.saveSessionKey(
             ownSessionKeyPair.privateKey,
             ownSessionKeyPair.sessionKey.keyId,
-            firstPartyEndpoint.privateAddress,
-            thirdPartyEndpoint.privateAddress
+            firstPartyEndpoint.nodeId,
+            thirdPartyEndpoint.nodeId
         )
         val peerSessionKey = SessionKeyPair.generate().sessionKey
-        sessionPublicKeystore.save(peerSessionKey, thirdPartyEndpoint.privateAddress)
+        sessionPublicKeystore.save(peerSessionKey, thirdPartyEndpoint.nodeId)
 
         thirdPartyEndpoint.delete()
 
-        verify(storage.publicThirdParty).delete(thirdPartyEndpoint.privateAddress)
-        assertEquals(0, privateKeyStore.sessionKeys[firstPartyEndpoint.privateAddress]!!.size)
+        verify(storage.publicThirdParty).delete(thirdPartyEndpoint.nodeId)
+        assertEquals(0, privateKeyStore.sessionKeys[firstPartyEndpoint.nodeId]!!.size)
         assertEquals(0, sessionPublicKeystore.keys.size)
         verify(channelManager).delete(thirdPartyEndpoint)
     }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointTest.kt
@@ -35,7 +35,12 @@ internal class PublicThirdPartyEndpointTest : MockContextTestCase() {
     fun load_successful() = runTest {
         val privateAddress = UUID.randomUUID().toString()
         whenever(storage.publicThirdParty.get(any()))
-            .thenReturn(PublicThirdPartyEndpointData(internetAddress, KeyPairSet.PDA_GRANTEE.public))
+            .thenReturn(
+                PublicThirdPartyEndpointData(
+                    internetAddress,
+                    KeyPairSet.PDA_GRANTEE.public
+                )
+            )
 
         val endpoint = PublicThirdPartyEndpoint.load(privateAddress)!!
         assertEquals(internetAddress, endpoint.internetAddress)

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/IncomingMessageTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/IncomingMessageTest.kt
@@ -52,7 +52,10 @@ internal class IncomingMessageTest : MockContextTestCase() {
         val thirdPartyEndpointManager = makeThirdPartyEndpointManager(channel)
         val serviceMessage = ServiceMessage("the type", "the content".toByteArray())
         val parcel = Parcel(
-            recipient = Recipient(channel.firstPartyEndpoint.nodeId, channel.firstPartyEndpoint.nodeId),
+            recipient = Recipient(
+                channel.firstPartyEndpoint.nodeId,
+                channel.firstPartyEndpoint.nodeId
+            ),
             payload = thirdPartyEndpointManager.wrapMessagePayload(
                 serviceMessage,
                 channel.firstPartyEndpoint.nodeId,

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/OutgoingMessageTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/OutgoingMessageTest.kt
@@ -5,7 +5,10 @@ import java.time.ZonedDateTime
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.*
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import tech.relaycorp.awaladroid.endpoint.PrivateThirdPartyEndpoint
 import tech.relaycorp.awaladroid.endpoint.PublicThirdPartyEndpoint
@@ -68,7 +71,10 @@ internal class OutgoingMessageTest : MockContextTestCase() {
         val message = MessageFactory.buildOutgoing(channel)
 
         assertEquals(message.recipientEndpoint.nodeId, message.parcel.recipient.id)
-        assertEquals(recipientPublicEndpoint.internetAddress, message.parcel.recipient.internetAddress)
+        assertEquals(
+            recipientPublicEndpoint.internetAddress,
+            message.parcel.recipient.internetAddress
+        )
         assertEquals(message.parcelId.value, message.parcel.id)
         assertSameDateTime(message.parcelCreationDate, message.parcel.creationDate)
         assertEquals(message.ttl, message.parcel.ttl)

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/OutgoingMessageTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/OutgoingMessageTest.kt
@@ -5,15 +5,14 @@ import java.time.ZonedDateTime
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertArrayEquals
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Test
 import tech.relaycorp.awaladroid.endpoint.PrivateThirdPartyEndpoint
+import tech.relaycorp.awaladroid.endpoint.PublicThirdPartyEndpoint
 import tech.relaycorp.awaladroid.test.MessageFactory
 import tech.relaycorp.awaladroid.test.MockContextTestCase
+import tech.relaycorp.awaladroid.test.RecipientAddressType
 import tech.relaycorp.awaladroid.test.assertSameDateTime
-import tech.relaycorp.relaynet.ramf.RecipientAddressType
 
 internal class OutgoingMessageTest : MockContextTestCase() {
 
@@ -64,10 +63,12 @@ internal class OutgoingMessageTest : MockContextTestCase() {
     @Test
     fun buildForPublicRecipient_checkBaseValues() = runTest {
         val channel = createEndpointChannel(RecipientAddressType.PUBLIC)
+        val recipientPublicEndpoint = channel.thirdPartyEndpoint as PublicThirdPartyEndpoint
 
         val message = MessageFactory.buildOutgoing(channel)
 
-        assertEquals(message.recipientEndpoint.address, message.parcel.recipientAddress)
+        assertEquals(message.recipientEndpoint.nodeId, message.parcel.recipient.id)
+        assertEquals(recipientPublicEndpoint.internetAddress, message.parcel.recipient.internetAddress)
         assertEquals(message.parcelId.value, message.parcel.id)
         assertSameDateTime(message.parcelCreationDate, message.parcel.creationDate)
         assertEquals(message.ttl, message.parcel.ttl)
@@ -118,7 +119,8 @@ internal class OutgoingMessageTest : MockContextTestCase() {
         val channel = createEndpointChannel(RecipientAddressType.PRIVATE)
         val message = MessageFactory.buildOutgoing(channel)
 
-        assertEquals(message.recipientEndpoint.address, message.parcel.recipientAddress)
+        assertEquals(message.recipientEndpoint.nodeId, message.parcel.recipient.id)
+        assertNull(message.parcel.recipient.internetAddress)
         assertEquals(message.parcelId.value, message.parcel.id)
         assertSameDateTime(message.parcelCreationDate, message.parcel.creationDate)
         assertEquals(message.ttl, message.parcel.ttl)

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/SendMessageTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/SendMessageTest.kt
@@ -8,11 +8,11 @@ import org.junit.Test
 import tech.relaycorp.awaladroid.GatewayProtocolException
 import tech.relaycorp.awaladroid.test.MessageFactory
 import tech.relaycorp.awaladroid.test.MockContextTestCase
+import tech.relaycorp.awaladroid.test.RecipientAddressType
 import tech.relaycorp.relaynet.bindings.pdc.ClientBindingException
 import tech.relaycorp.relaynet.bindings.pdc.RejectedParcelException
 import tech.relaycorp.relaynet.bindings.pdc.ServerConnectionException
 import tech.relaycorp.relaynet.messages.Parcel
-import tech.relaycorp.relaynet.ramf.RecipientAddressType
 import tech.relaycorp.relaynet.testing.pdc.DeliverParcelCall
 import tech.relaycorp.relaynet.testing.pdc.MockPDCClient
 
@@ -48,8 +48,8 @@ internal class SendMessageTest : MockContextTestCase() {
         assertTrue(deliverParcelCall.wasCalled)
         val signer = deliverParcelCall.arguments!!.deliverySigner
         assertEquals(
-            message.senderEndpoint.identityCertificate.subjectPrivateAddress,
-            signer.certificate.subjectPrivateAddress
+            message.senderEndpoint.identityCertificate.subjectId,
+            signer.certificate.subjectId
         )
     }
 

--- a/lib/src/test/java/tech/relaycorp/awaladroid/storage/MockStorage.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/storage/MockStorage.kt
@@ -4,7 +4,8 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 
 internal fun mockStorage() = mock<StorageImpl> {
-    on { gatewayPrivateAddress } doReturn mock()
+    on { gatewayId } doReturn mock()
+    on { internetAddress } doReturn mock()
     on { publicThirdParty } doReturn mock()
     on { privateThirdParty } doReturn mock()
 }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/storage/StorageImplTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/storage/StorageImplTest.kt
@@ -24,17 +24,17 @@ internal class StorageImplTest {
     private val storage = StorageImpl(persistence)
 
     @Test
-    fun gatewayPrivateAddress() = runTest {
+    fun gatewayId() = runTest {
         val charset = Charset.forName("ASCII")
-        storage.gatewayPrivateAddress.testGet(
+        storage.gatewayId.testGet(
             PDACertPath.PRIVATE_GW.subjectId.toByteArray(charset),
             PDACertPath.PRIVATE_GW.subjectId
         )
-        storage.gatewayPrivateAddress.testSet(
+        storage.gatewayId.testSet(
             PDACertPath.PRIVATE_GW.subjectId,
             PDACertPath.PRIVATE_GW.subjectId.toByteArray(charset),
         )
-        storage.gatewayPrivateAddress.testDelete()
+        storage.gatewayId.testDelete()
     }
 
     @Test

--- a/lib/src/test/java/tech/relaycorp/awaladroid/storage/StorageImplTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/storage/StorageImplTest.kt
@@ -27,12 +27,12 @@ internal class StorageImplTest {
     fun gatewayPrivateAddress() = runTest {
         val charset = Charset.forName("ASCII")
         storage.gatewayPrivateAddress.testGet(
-            PDACertPath.PRIVATE_GW.subjectPrivateAddress.toByteArray(charset),
-            PDACertPath.PRIVATE_GW.subjectPrivateAddress
+            PDACertPath.PRIVATE_GW.subjectId.toByteArray(charset),
+            PDACertPath.PRIVATE_GW.subjectId
         )
         storage.gatewayPrivateAddress.testSet(
-            PDACertPath.PRIVATE_GW.subjectPrivateAddress,
-            PDACertPath.PRIVATE_GW.subjectPrivateAddress.toByteArray(charset),
+            PDACertPath.PRIVATE_GW.subjectId,
+            PDACertPath.PRIVATE_GW.subjectId.toByteArray(charset),
         )
         storage.gatewayPrivateAddress.testDelete()
     }
@@ -63,7 +63,7 @@ internal class StorageImplTest {
     fun publicThirdParty() = runTest {
         val data = PublicThirdPartyEndpointData(
             "example.org",
-            KeyPairSet.PUBLIC_GW.public
+            KeyPairSet.INTERNET_GW.public
         )
         val rawData = data.serialize()
 

--- a/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
@@ -7,19 +7,13 @@ import org.junit.Before
 import org.mockito.internal.util.MockUtil
 import tech.relaycorp.awaladroid.AwalaContext
 import tech.relaycorp.awaladroid.GatewayClientImpl
-import tech.relaycorp.awaladroid.endpoint.ChannelManager
-import tech.relaycorp.awaladroid.endpoint.FirstPartyEndpoint
-import tech.relaycorp.awaladroid.endpoint.HandleGatewayCertificateChange
-import tech.relaycorp.awaladroid.endpoint.PrivateThirdPartyEndpointData
-import tech.relaycorp.awaladroid.endpoint.PublicThirdPartyEndpointData
-import tech.relaycorp.awaladroid.endpoint.ThirdPartyEndpoint
+import tech.relaycorp.awaladroid.endpoint.*
 import tech.relaycorp.awaladroid.storage.StorageImpl
 import tech.relaycorp.awaladroid.storage.mockStorage
 import tech.relaycorp.relaynet.SessionKey
 import tech.relaycorp.relaynet.SessionKeyPair
 import tech.relaycorp.relaynet.nodes.EndpointManager
 import tech.relaycorp.relaynet.pki.CertificationPath
-import tech.relaycorp.relaynet.ramf.RecipientAddressType
 import tech.relaycorp.relaynet.testing.keystores.MockCertificateStore
 import tech.relaycorp.relaynet.testing.keystores.MockPrivateKeyStore
 import tech.relaycorp.relaynet.testing.keystores.MockSessionPublicKeyStore
@@ -78,12 +72,12 @@ internal abstract class MockContextTestCase {
         privateKeyStore.saveSessionKey(
             firstPartySessionKeyPair.privateKey,
             firstPartySessionKeyPair.sessionKey.keyId,
-            firstPartyEndpoint.privateAddress,
-            thirdPartyEndpoint.privateAddress,
+            firstPartyEndpoint.nodeId,
+            thirdPartyEndpoint.nodeId,
         )
 
         whenever(channelManager.getLinkedEndpointAddresses(firstPartyEndpoint))
-            .thenReturn(setOf(thirdPartyEndpoint.privateAddress))
+            .thenReturn(setOf(thirdPartyEndpoint.nodeId))
 
         return EndpointChannel(
             firstPartyEndpoint,
@@ -109,11 +103,11 @@ internal abstract class MockContextTestCase {
         )
 
         if (MockUtil.isMock(storage)) {
-            whenever(storage.gatewayPrivateAddress.get(firstPartyEndpoint.privateAddress))
+            whenever(storage.gatewayPrivateAddress.get(firstPartyEndpoint.nodeId))
                 .thenReturn(certificate.issuerCommonName)
         } else {
             storage.gatewayPrivateAddress.set(
-                firstPartyEndpoint.privateAddress,
+                firstPartyEndpoint.nodeId,
                 certificate.issuerCommonName
             )
         }
@@ -136,7 +130,7 @@ internal abstract class MockContextTestCase {
                 )
                 whenever(
                     storage.privateThirdParty.get(
-                        "${firstPartyEndpoint.privateAddress}_${thirdPartyEndpoint.privateAddress}"
+                        "${firstPartyEndpoint.nodeId}_${thirdPartyEndpoint.nodeId}"
                     )
                 ).thenReturn(
                     PrivateThirdPartyEndpointData(
@@ -148,10 +142,10 @@ internal abstract class MockContextTestCase {
             else -> {
                 thirdPartyEndpoint = ThirdPartyEndpointFactory.buildPublic()
                 whenever(
-                    storage.publicThirdParty.get(thirdPartyEndpoint.privateAddress)
+                    storage.publicThirdParty.get(thirdPartyEndpoint.nodeId)
                 ).thenReturn(
                     PublicThirdPartyEndpointData(
-                        thirdPartyEndpoint.publicAddress,
+                        thirdPartyEndpoint.internetAddress,
                         thirdPartyEndpoint.identityKey
                     )
                 )
@@ -160,7 +154,7 @@ internal abstract class MockContextTestCase {
 
         sessionPublicKeystore.save(
             sessionKey,
-            thirdPartyEndpoint.privateAddress
+            thirdPartyEndpoint.nodeId
         )
         return thirdPartyEndpoint
     }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
@@ -7,7 +7,12 @@ import org.junit.Before
 import org.mockito.internal.util.MockUtil
 import tech.relaycorp.awaladroid.AwalaContext
 import tech.relaycorp.awaladroid.GatewayClientImpl
-import tech.relaycorp.awaladroid.endpoint.*
+import tech.relaycorp.awaladroid.endpoint.ChannelManager
+import tech.relaycorp.awaladroid.endpoint.FirstPartyEndpoint
+import tech.relaycorp.awaladroid.endpoint.HandleGatewayCertificateChange
+import tech.relaycorp.awaladroid.endpoint.PrivateThirdPartyEndpointData
+import tech.relaycorp.awaladroid.endpoint.PublicThirdPartyEndpointData
+import tech.relaycorp.awaladroid.endpoint.ThirdPartyEndpoint
 import tech.relaycorp.awaladroid.storage.StorageImpl
 import tech.relaycorp.awaladroid.storage.mockStorage
 import tech.relaycorp.relaynet.SessionKey

--- a/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
@@ -94,6 +94,7 @@ internal abstract class MockContextTestCase {
 
     protected suspend fun createFirstPartyEndpoint(): FirstPartyEndpoint {
         val firstPartyEndpoint = FirstPartyEndpointFactory.build()
+        val gatewayAddress = "example.org"
         privateKeyStore.saveIdentityKey(
             firstPartyEndpoint.identityPrivateKey,
         )
@@ -108,12 +109,19 @@ internal abstract class MockContextTestCase {
         )
 
         if (MockUtil.isMock(storage)) {
-            whenever(storage.gatewayPrivateAddress.get(firstPartyEndpoint.nodeId))
+            whenever(storage.gatewayId.get(firstPartyEndpoint.nodeId))
                 .thenReturn(certificate.issuerCommonName)
+
+            whenever(storage.internetAddress.get(gatewayAddress))
+                .thenReturn(gatewayAddress)
         } else {
-            storage.gatewayPrivateAddress.set(
+            storage.gatewayId.set(
                 firstPartyEndpoint.nodeId,
                 certificate.issuerCommonName
+            )
+
+            storage.internetAddress.set(
+                gatewayAddress
             )
         }
 

--- a/lib/src/test/java/tech/relaycorp/awaladroid/test/RecipientAddressType.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/test/RecipientAddressType.kt
@@ -1,0 +1,5 @@
+package tech.relaycorp.awaladroid.test
+
+public enum class RecipientAddressType {
+    PRIVATE, PUBLIC
+}

--- a/lib/src/test/java/tech/relaycorp/awaladroid/test/ThirdPartyEndpointFactory.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/test/ThirdPartyEndpointFactory.kt
@@ -12,7 +12,7 @@ internal object ThirdPartyEndpointFactory {
     )
 
     fun buildPrivate(): PrivateThirdPartyEndpoint = PrivateThirdPartyEndpoint(
-        PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress,
+        PDACertPath.PRIVATE_ENDPOINT.subjectId,
         KeyPairSet.PDA_GRANTEE.public,
         PDACertPath.PDA,
         listOf(PDACertPath.PRIVATE_GW)


### PR DESCRIPTION
This PR updates the Awala Endpoint library to address the issues related to: https://github.com/relaycorp/relayverse/issues/40