### PR TITLE
fix: NonceSignerException crash when ReceiveMessages.receive is called without first-part endpoints

### DIFF
--- a/lib/src/main/java/tech/relaycorp/awaladroid/messaging/ReceiveMessages.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/messaging/ReceiveMessages.kt
@@ -45,7 +45,7 @@ internal class ReceiveMessages(
                 if (nonceSigners.isEmpty()) {
                     logger.log(
                         Level.WARNING,
-                        "Skipping parcel collection because there are no first-party endpoints registered yet",
+                        "Skipping parcel collection because there are no first-party endpoints",
                     )
                     return@flatMapLatest emptyFlow()
                 }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/ReceiveMessagesTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/ReceiveMessagesTest.kt
@@ -120,7 +120,7 @@ internal class ReceiveMessagesTest : MockContextTestCase() {
         assertFalse(collectParcelsCall.wasCalled)
         assertTrue(
             logCaptor.warnLogs.contains(
-                "Skipping parcel collection because there are no first-party endpoints registered yet",
+                "Skipping parcel collection because there are no first-party endpoints",
             ),
         )
     }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
@@ -92,8 +92,9 @@ internal abstract class MockContextTestCase {
         )
     }
 
-    protected suspend fun createFirstPartyEndpoint(): FirstPartyEndpoint {
-        val firstPartyEndpoint = FirstPartyEndpointFactory.build()
+    protected suspend fun createFirstPartyEndpoint(
+        firstPartyEndpoint: FirstPartyEndpoint = FirstPartyEndpointFactory.build(),
+    ): FirstPartyEndpoint {
         val gatewayAddress = "example.org"
         privateKeyStore.saveIdentityKey(
             firstPartyEndpoint.identityPrivateKey,


### PR DESCRIPTION
Also skips parcel collection without 1st party endpoints.

Closes #338