### PR TITLE
fix(OutgoingMessage): Throw `InvalidMessageException` when parcel is too big

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -64,7 +64,7 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
 
   // Awala
-  implementation 'tech.relaycorp:awala:1.67.10'
+  implementation 'tech.relaycorp:awala:1.68.0'
   implementation 'tech.relaycorp:awala-keystore-file:1.6.31'
   implementation 'tech.relaycorp:poweb:1.5.68'
   testImplementation 'tech.relaycorp:awala-testing:1.5.24'

--- a/lib/src/main/java/tech/relaycorp/awaladroid/messaging/InvalidMessageException.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/messaging/InvalidMessageException.kt
@@ -1,0 +1,11 @@
+package tech.relaycorp.awaladroid.messaging
+
+import tech.relaycorp.awaladroid.AwaladroidException
+
+/**
+ * Exception thrown when an incoming or outgoing service message is invalid.
+ */
+public class InvalidMessageException(
+    message: String,
+    cause: Throwable,
+) : AwaladroidException(message, cause)

--- a/lib/src/main/java/tech/relaycorp/awaladroid/messaging/Message.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/messaging/Message.kt
@@ -1,6 +1,18 @@
 package tech.relaycorp.awaladroid.messaging
 
+import tech.relaycorp.relaynet.ramf.RAMFMessage
+
 /**
  * A service message.
  */
-public abstract class Message
+public abstract class Message {
+    public companion object {
+        private const val PESSIMISTIC_CMS_ENVELOPEDDATA_OVERHEAD_OCTETS = 1024
+
+        /**
+         * The maximum size of the content of a message.
+         */
+        public const val MAX_CONTENT_SIZE: Int =
+            RAMFMessage.MAX_PAYLOAD_LENGTH - PESSIMISTIC_CMS_ENVELOPEDDATA_OVERHEAD_OCTETS
+    }
+}

--- a/lib/src/main/java/tech/relaycorp/awaladroid/messaging/OutgoingMessage.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/messaging/OutgoingMessage.kt
@@ -44,13 +44,14 @@ private constructor(
         /**
          * Create an outgoing service message (but don't send it).
          *
-         * @param type The type of the message (e.g., "application/vnd.relaynet.ping-v1.ping").
+         * @param type The type of the message (e.g., "application/vnd.awala.ping-v1.ping").
          * @param content The contents of the service message.
          * @param senderEndpoint The endpoint used to send the message.
          * @param recipientEndpoint The endpoint that will receive the message.
          * @param parcelExpiryDate The date when the parcel should expire.
          * @param parcelId The id of the parcel.
          */
+        @Throws(InvalidMessageException::class)
         public suspend fun build(
             type: String,
             content: ByteArray,
@@ -71,6 +72,7 @@ private constructor(
         }
     }
 
+    @Throws(InvalidMessageException::class)
     private suspend fun buildParcel(
         serviceMessageType: String,
         serviceMessageContent: ByteArray,

--- a/lib/src/main/java/tech/relaycorp/awaladroid/messaging/OutgoingMessage.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/messaging/OutgoingMessage.kt
@@ -8,6 +8,7 @@ import tech.relaycorp.awaladroid.endpoint.ThirdPartyEndpoint
 import tech.relaycorp.relaynet.issueEndpointCertificate
 import tech.relaycorp.relaynet.messages.Parcel
 import tech.relaycorp.relaynet.messages.payloads.ServiceMessage
+import tech.relaycorp.relaynet.ramf.RAMFException
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 import java.time.Duration
 import java.time.ZonedDateTime
@@ -81,15 +82,20 @@ private constructor(
             recipientEndpoint.nodeId,
             senderEndpoint.nodeId,
         )
-        return Parcel(
-            recipient = recipientEndpoint.recipient,
-            payload = payload,
-            senderCertificate = getSenderCertificate(),
-            messageId = parcelId.value,
-            creationDate = parcelCreationDate,
-            ttl = ttl,
-            senderCertificateChain = getSenderCertificateChain(),
-        )
+        val parcel = try {
+            Parcel(
+                recipient = recipientEndpoint.recipient,
+                payload = payload,
+                senderCertificate = getSenderCertificate(),
+                messageId = parcelId.value,
+                creationDate = parcelCreationDate,
+                ttl = ttl,
+                senderCertificateChain = getSenderCertificateChain(),
+            )
+        } catch (exc: RAMFException) {
+            throw InvalidMessageException("Failed to create parcel", exc)
+        }
+        return parcel
     }
 
     private fun getSenderCertificate(): Certificate =

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/MessageTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/MessageTest.kt
@@ -1,0 +1,14 @@
+package tech.relaycorp.awaladroid.messaging
+
+import org.junit.Assert
+import org.junit.Test
+import tech.relaycorp.relaynet.ramf.RAMFMessage
+
+public class MessageTest {
+    @Test
+    public fun maxContentSize() {
+        val expectedMax = RAMFMessage.MAX_PAYLOAD_LENGTH - 1024
+
+        Assert.assertEquals(Message.MAX_CONTENT_SIZE, expectedMax)
+    }
+}

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/OutgoingMessageTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/OutgoingMessageTest.kt
@@ -1,8 +1,10 @@
 package tech.relaycorp.awaladroid.messaging
 
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import tech.relaycorp.awaladroid.endpoint.PrivateThirdPartyEndpoint
@@ -11,6 +13,7 @@ import tech.relaycorp.awaladroid.test.MessageFactory
 import tech.relaycorp.awaladroid.test.MockContextTestCase
 import tech.relaycorp.awaladroid.test.RecipientAddressType
 import tech.relaycorp.awaladroid.test.assertSameDateTime
+import tech.relaycorp.relaynet.ramf.RAMFException
 import java.time.Duration
 import java.time.ZonedDateTime
 import kotlin.math.abs
@@ -58,6 +61,25 @@ internal class OutgoingMessageTest : MockContextTestCase() {
         val differenceSeconds =
             Duration.between(message.parcel.expiryDate, parcelExpiryDate).seconds
         assertTrue(abs(differenceSeconds) < 3)
+    }
+
+    @Test
+    fun build_bigServiceMessage() = runTest {
+        val (senderEndpoint, recipientEndpoint) = createEndpointChannel(RecipientAddressType.PUBLIC)
+
+        val exception = assertThrows(InvalidMessageException::class.java) {
+            runBlocking {
+                OutgoingMessage.build(
+                    "the type",
+                    ByteArray(8388608 + 1),
+                    senderEndpoint,
+                    recipientEndpoint,
+                )
+            }
+        }
+
+        assertEquals("Failed to create parcel", exception.message)
+        assertTrue(exception.cause is RAMFException)
     }
 
     // Public Recipient

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/OutgoingMessageTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/OutgoingMessageTest.kt
@@ -21,7 +21,6 @@ import kotlin.math.abs
 import kotlin.random.Random
 
 internal class OutgoingMessageTest : MockContextTestCase() {
-
     @Test
     fun build_creationDate() = runTest {
         val channel = createEndpointChannel(RecipientAddressType.PRIVATE)

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/OutgoingMessageTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/OutgoingMessageTest.kt
@@ -14,6 +14,7 @@ import tech.relaycorp.awaladroid.test.MockContextTestCase
 import tech.relaycorp.awaladroid.test.RecipientAddressType
 import tech.relaycorp.awaladroid.test.assertSameDateTime
 import tech.relaycorp.relaynet.ramf.RAMFException
+import tech.relaycorp.relaynet.ramf.RAMFMessage
 import java.time.Duration
 import java.time.ZonedDateTime
 import kotlin.math.abs
@@ -71,7 +72,7 @@ internal class OutgoingMessageTest : MockContextTestCase() {
             runBlocking {
                 OutgoingMessage.build(
                     "the type",
-                    ByteArray(8388608 + 1),
+                    ByteArray(RAMFMessage.MAX_PAYLOAD_LENGTH + 1),
                     senderEndpoint,
                     recipientEndpoint,
                 )


### PR DESCRIPTION
- [x] Upgrade Awala lib to use newly-exported constant.
- [x] Export max size of parcel payload.