### PR TITLE
feat(FirstPartyEndpoint): Expose third-party node id when authorising

### DIFF
--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpoint.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpoint.kt
@@ -57,7 +57,7 @@ internal constructor(
         issueAuthorization(
             thirdPartyEndpoint.identityKey,
             expiryDate,
-        )
+        ).auth
 
     /**
      * Issue a PDA for a third-party endpoint using its public key.
@@ -66,7 +66,7 @@ internal constructor(
     public suspend fun issueAuthorization(
         thirdPartyEndpointPublicKeySerialized: ByteArray,
         expiryDate: ZonedDateTime,
-    ): ByteArray {
+    ): ThirdPartyEndpointAuth {
         val thirdPartyEndpointPublicKey =
             deserializePDAGranteePublicKey(thirdPartyEndpointPublicKeySerialized)
         return issueAuthorization(thirdPartyEndpointPublicKey, expiryDate)
@@ -76,7 +76,7 @@ internal constructor(
     private suspend fun issueAuthorization(
         thirdPartyEndpointPublicKey: PublicKey,
         expiryDate: ZonedDateTime,
-    ): ByteArray {
+    ): ThirdPartyEndpointAuth {
         val pda = issueDeliveryAuthorization(
             subjectPublicKey = thirdPartyEndpointPublicKey,
             issuerPrivateKey = identityPrivateKey,
@@ -97,7 +97,8 @@ internal constructor(
             deliveryAuth,
             sessionKeyPair.sessionKey,
         )
-        return connParams.serialize()
+        val authSerialized = connParams.serialize()
+        return ThirdPartyEndpointAuth(thirdPartyEndpointPublicKey.nodeId, authSerialized)
     }
 
     /**
@@ -107,7 +108,7 @@ internal constructor(
     public suspend fun authorizeIndefinitely(
         thirdPartyEndpoint: ThirdPartyEndpoint,
     ): ByteArray =
-        authorizeIndefinitely(thirdPartyEndpoint.identityKey)
+        authorizeIndefinitely(thirdPartyEndpoint.identityKey).auth
 
     /**
      * Issue a PDA for a third-party endpoint (using its public key) and renew it indefinitely.
@@ -115,7 +116,7 @@ internal constructor(
     @Throws(CertificateException::class)
     public suspend fun authorizeIndefinitely(
         thirdPartyEndpointPublicKeySerialized: ByteArray,
-    ): ByteArray {
+    ): ThirdPartyEndpointAuth {
         val thirdPartyEndpointPublicKey =
             deserializePDAGranteePublicKey(thirdPartyEndpointPublicKeySerialized)
         return authorizeIndefinitely(thirdPartyEndpointPublicKey)
@@ -124,7 +125,7 @@ internal constructor(
     @Throws(CertificateException::class)
     private suspend fun authorizeIndefinitely(
         thirdPartyEndpointPublicKey: PublicKey,
-    ): ByteArray {
+    ): ThirdPartyEndpointAuth {
         val authorization =
             issueAuthorization(thirdPartyEndpointPublicKey, identityCertificate.expiryDate)
 

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ThirdPartyEndpointAuth.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ThirdPartyEndpointAuth.kt
@@ -1,0 +1,16 @@
+package tech.relaycorp.awaladroid.endpoint
+
+/**
+ * Parcel delivery authorization for a third-party endpoint.
+ */
+public class ThirdPartyEndpointAuth(
+    /**
+     * Id of the third-party endpoint.
+     */
+    public val endpointId: String,
+
+    /**
+     * The authorization serialized.
+     */
+    public val auth: ByteArray,
+)

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/FirstPartyEndpointTest.kt
@@ -443,6 +443,19 @@ internal class FirstPartyEndpointTest : MockContextTestCase() {
 }
 
 private fun validateAuthorization(
+    auth: ThirdPartyEndpointAuth,
+    firstPartyEndpoint: FirstPartyEndpoint,
+    expiryDate: ZonedDateTime,
+) {
+    assertEquals(
+        auth.endpointId,
+        KeyPairSet.PDA_GRANTEE.public.nodeId,
+    )
+
+    validateAuthorization(auth.auth, firstPartyEndpoint, expiryDate)
+}
+
+private fun validateAuthorization(
     paramsSerialized: ByteArray,
     firstPartyEndpoint: FirstPartyEndpoint,
     expiryDate: ZonedDateTime,


### PR DESCRIPTION
Needed in https://github.com/relaycorp/letro-android/pull/162
