### PR TITLE
fix: Allow multiple first-party endpoints to communicate with the same third-party endpoint

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -66,8 +66,8 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
 
   // Awala
-  implementation 'tech.relaycorp:awala:1.68.0'
-  implementation 'tech.relaycorp:awala-keystore-file:1.6.31'
+  implementation 'tech.relaycorp:awala:1.68.5'
+  implementation 'tech.relaycorp:awala-keystore-file:1.6.38'
   implementation 'tech.relaycorp:poweb:1.5.68'
   testImplementation 'tech.relaycorp:awala-testing:1.5.24'
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -69,7 +69,7 @@ dependencies {
   implementation 'tech.relaycorp:awala:1.68.5'
   implementation 'tech.relaycorp:awala-keystore-file:1.6.39'
   implementation 'tech.relaycorp:poweb:1.5.68'
-  testImplementation 'tech.relaycorp:awala-testing:1.5.24'
+  testImplementation 'tech.relaycorp:awala-testing:1.5.27'
 
   // Security
   implementation 'androidx.security:security-crypto:1.1.0-alpha06'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 
   // Awala
   implementation 'tech.relaycorp:awala:1.68.5'
-  implementation 'tech.relaycorp:awala-keystore-file:1.6.38'
+  implementation 'tech.relaycorp:awala-keystore-file:1.6.39'
   implementation 'tech.relaycorp:poweb:1.5.68'
   testImplementation 'tech.relaycorp:awala-testing:1.5.24'
 

--- a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
+++ b/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ChannelManager.kt
@@ -54,7 +54,10 @@ internal class ChannelManager(
         }
     }
 
-    suspend fun delete(thirdPartyEndpoint: ThirdPartyEndpoint) {
+    suspend fun delete(
+        linkedFirstPartyEndpoint: FirstPartyEndpoint,
+        thirdPartyEndpoint: ThirdPartyEndpoint,
+    ) {
         withContext(coroutineContext) {
             sharedPreferences.all.forEach { (key, value) ->
                 // Skip malformed values
@@ -63,6 +66,10 @@ internal class ChannelManager(
                 }
                 val sanitizedValue: List<String> = value.filterIsInstance<String>()
                 if (value.size != sanitizedValue.size) {
+                    return@forEach
+                }
+
+                if (key != linkedFirstPartyEndpoint.nodeId) {
                     return@forEach
                 }
 

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/ChannelManagerTest.kt
@@ -124,7 +124,7 @@ internal class ChannelManagerTest {
                 apply()
             }
 
-            manager.delete(thirdPartyEndpoint)
+            manager.delete(firstPartyEndpoint, thirdPartyEndpoint)
 
             assertEquals(
                 mutableSetOf(unrelatedThirdPartyEndpointAddress),
@@ -145,7 +145,7 @@ internal class ChannelManagerTest {
                 apply()
             }
 
-            manager.delete(thirdPartyEndpoint)
+            manager.delete(firstPartyEndpoint, thirdPartyEndpoint)
 
             assertEquals(
                 setOf(unrelatedThirdPartyEndpointAddress),
@@ -166,7 +166,7 @@ internal class ChannelManagerTest {
                 apply()
             }
 
-            manager.delete(thirdPartyEndpoint)
+            manager.delete(firstPartyEndpoint, thirdPartyEndpoint)
 
             assertEquals(
                 malformedValue,
@@ -187,7 +187,7 @@ internal class ChannelManagerTest {
                 apply()
             }
 
-            manager.delete(thirdPartyEndpoint)
+            manager.delete(firstPartyEndpoint, thirdPartyEndpoint)
 
             assertEquals(
                 malformedValue,

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PrivateThirdPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PrivateThirdPartyEndpointTest.kt
@@ -145,7 +145,10 @@ internal class PrivateThirdPartyEndpointTest : MockContextTestCase() {
                 },
             )
 
-            assertEquals(sessionKey, sessionPublicKeystore.retrieve(endpoint.nodeId))
+            assertEquals(
+                sessionKey,
+                sessionPublicKeystore.retrieve(firstPartyEndpoint.nodeId, endpoint.nodeId),
+            )
         }
 
     @Test

--- a/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/endpoint/PublicThirdPartyEndpointTest.kt
@@ -152,7 +152,7 @@ internal class PublicThirdPartyEndpointTest : MockContextTestCase() {
 
             verify(storage.publicThirdParty).delete(thirdPartyEndpoint.nodeId)
             assertEquals(0, privateKeyStore.sessionKeys[firstPartyEndpoint.nodeId]!!.size)
-            assertEquals(0, sessionPublicKeystore.keys.size)
+            assertEquals(0, sessionPublicKeystore.keys[firstPartyEndpoint.nodeId]!!.size)
             verify(channelManager).delete(firstPartyEndpoint, thirdPartyEndpoint)
         }
 }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/IncomingMessageTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/IncomingMessageTest.kt
@@ -279,6 +279,7 @@ internal class IncomingMessageTest : MockContextTestCase() {
         thirdPartySessionPublicKeyStore.save(
             channel.firstPartySessionKeyPair.sessionKey,
             channel.firstPartyEndpoint.nodeId,
+            channel.thirdPartyEndpoint.nodeId,
         )
         return EndpointManager(
             thirdPartyPrivateKeyStore,

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/IncomingMessageTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/IncomingMessageTest.kt
@@ -65,8 +65,8 @@ internal class IncomingMessageTest : MockContextTestCase() {
                     payload =
                         thirdPartyEndpointManager.wrapMessagePayload(
                             serviceMessage,
-                            channel.firstPartyEndpoint.nodeId,
                             channel.thirdPartyEndpoint.nodeId,
+                            channel.firstPartyEndpoint.nodeId,
                         ),
                     senderCertificate = PDACertPath.PDA,
                 )
@@ -300,8 +300,8 @@ internal class IncomingMessageTest : MockContextTestCase() {
         val pdaPathServiceMessage = makePDAPathMessage(plaintext)
         return thirdPartyEndpointManager.wrapMessagePayload(
             pdaPathServiceMessage,
-            channel.firstPartyEndpoint.nodeId,
             channel.thirdPartyEndpoint.nodeId,
+            channel.firstPartyEndpoint.nodeId,
         )
     }
 
@@ -311,7 +311,8 @@ internal class IncomingMessageTest : MockContextTestCase() {
     companion object {
         private val logCaptor = LogCaptor.forClass(IncomingMessage::class.java)
 
+        @JvmStatic
         @AfterClass
-        fun closeLogs() = logCaptor.close()
+        fun closeLogs(): Unit = logCaptor.close()
     }
 }

--- a/lib/src/test/java/tech/relaycorp/awaladroid/messaging/ReceiveMessagesTest.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/messaging/ReceiveMessagesTest.kt
@@ -218,7 +218,7 @@ internal class ReceiveMessagesTest : MockContextTestCase() {
             val collectParcelsCall = CollectParcelsCall(Result.success(flowOf(parcelCollection)))
             pdcClient = MockPDCClient(collectParcelsCall)
 
-            channel.thirdPartyEndpoint.delete()
+            channel.thirdPartyEndpoint.delete(channel.firstPartyEndpoint)
 
             val messages = subject.receive().toCollection(mutableListOf())
 

--- a/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
+++ b/lib/src/test/java/tech/relaycorp/awaladroid/test/MockContextTestCase.kt
@@ -171,6 +171,7 @@ internal abstract class MockContextTestCase {
 
         sessionPublicKeystore.save(
             sessionKey,
+            firstPartyEndpoint.nodeId,
             thirdPartyEndpoint.nodeId,
         )
         return thirdPartyEndpoint


### PR DESCRIPTION
Due to bugs in the key stores (https://github.com/relaycorp/awala-jvm/pull/306, https://github.com/relaycorp/awala-jvm/pull/310), we were accidentally reusing the same session keys, which the third-party endpoint rightfully refused.

This PR will integrate the two breaking changes above, plus one additional change needed to make this work.

A consequence of this change is that **we'll now need to pass the linked first-party endpoint when importing and deleting a third-party endpoint**, so that we know which session keys to delete in case the same third-party endpoint is used by another first-party endpoint.

# TODO

Each of the following require updating the respective test suite.

- [x] Pass first-party endpoint to every function call inside `ThirdPartyEndpoint.delete()`:

  https://github.com/relaycorp/awala-endpoint-android/blob/6ecb5345d67bf29033b0e27a02d91e7d1b35c02a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ThirdPartyEndpoint.kt#L31-L36

  This should look like this, roughly (untested):

  ```kotlin
  public open suspend fun delete(linkedFirstPartyEndpoint: FirstPartyEndpoint) {
    val context = Awala.getContextOrThrow()
    context.privateKeyStore.deleteBoundSessionKeys(linkedFirstPartyEndpoint.nodeId, nodeId) 
    context.sessionPublicKeyStore.delete(linkedFirstPartyEndpoint.nodeId, nodeId) 
    context.channelManager.delete(linkedFirstPartyEndpoint, this)
  }
  ```
- [x] Replace `delete(ThirdPartyEndpoint)` in `ChannelManager` with `delete(FirstPartyEndpoint, ThirdPartyEndpoint)`, and only delete the items for the given first-/third-party endpoint pair. This change is needed by the previous task.
- [x] Replace `import(ByteArray)` in `PrivateThirdPartyEndpoint` with `import(ByteArray, FirstPartyEndpoint)`, and pass the first-party endpoint to

  https://github.com/relaycorp/awala-endpoint-android/blob/6ecb5345d67bf29033b0e27a02d91e7d1b35c02a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ThirdPartyEndpoint.kt#L183
- [x] Replace `import(ByteArray)` in `PublicThirdPartyEndpoint` with `import(ByteArray, FirstPartyEndpoint)`, and pass the first-party endpoint to

  https://github.com/relaycorp/awala-endpoint-android/blob/6ecb5345d67bf29033b0e27a02d91e7d1b35c02a/lib/src/main/java/tech/relaycorp/awaladroid/endpoint/ThirdPartyEndpoint.kt#L249-L252
